### PR TITLE
Print button on landing pages #164

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.2.3).
+ * Mock Service Worker (1.3.2).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/src/catalogue/items/catalogueItemsLandingPage.component.test.tsx
+++ b/src/catalogue/items/catalogueItemsLandingPage.component.test.tsx
@@ -209,7 +209,7 @@ describe('Catalogue Items Landing Page', () => {
     ).toBeInTheDocument();
   });
 
-  it.only('prints when the button is clicked', async () => {
+  it('prints when the button is clicked', async () => {
     const spy = jest.spyOn(window, 'print').mockImplementation(() => {});
     createView('/inventory-management-system/catalogue/items/89');
 

--- a/src/catalogue/items/catalogueItemsLandingPage.component.test.tsx
+++ b/src/catalogue/items/catalogueItemsLandingPage.component.test.tsx
@@ -208,4 +208,22 @@ describe('Catalogue Items Landing Page', () => {
       screen.getByRole('link', { name: 'Click here' })
     ).toBeInTheDocument();
   });
+
+  it.only('prints when the button is clicked', async () => {
+    const spy = jest.spyOn(window, 'print').mockImplementation(() => {});
+    createView('/inventory-management-system/catalogue/items/89');
+
+    await waitFor(() => {
+      expect(screen.getByText('Energy Meters 26')).toBeInTheDocument();
+    });
+
+    const printButton = screen.getByRole('button', { name: 'Print' });
+
+    await user.click(printButton);
+    // Assert that the window.print() function was called
+    expect(spy).toHaveBeenCalled();
+
+    // Clean up the mock
+    spy.mockRestore();
+  });
 });

--- a/src/catalogue/items/catalogueItemsLandingPage.component.test.tsx
+++ b/src/catalogue/items/catalogueItemsLandingPage.component.test.tsx
@@ -211,7 +211,7 @@ describe('Catalogue Items Landing Page', () => {
 
   it('prints when the button is clicked', async () => {
     const spy = jest.spyOn(window, 'print').mockImplementation(() => {});
-    createView('/inventory-management-system/catalogue/items/89');
+    createView('/catalogue/items/89');
 
     await waitFor(() => {
       expect(screen.getByText('Energy Meters 26')).toBeInTheDocument();

--- a/src/catalogue/items/catalogueItemsLandingPage.component.tsx
+++ b/src/catalogue/items/catalogueItemsLandingPage.component.tsx
@@ -75,7 +75,7 @@ function CatalogueItemsLandingPage() {
               ? `/inventory-management-system/catalogue/${catalogueCategoryData.id}`
               : '/inventory-management-system/catalogue'
           }
-          sx={{ margin: 1 }}
+          sx={{ mx: 0.5 }}
           variant="outlined"
         >
           {catalogueItemIdData
@@ -84,13 +84,22 @@ function CatalogueItemsLandingPage() {
         </Button>
         <Button
           disabled={!catalogueItemIdData}
-          sx={{ margin: 1 }}
+          sx={{ mx: 0.5 }}
           variant="outlined"
           onClick={() => {
             setEditItemDialogOpen(true);
           }}
         >
           Edit
+        </Button>
+        <Button
+          sx={{ mx: 0.5 }}
+          variant="outlined"
+          onClick={() => {
+            window.print();
+          }}
+        >
+          Print
         </Button>
       </Grid>
       {catalogueItemIdData && (

--- a/src/catalogue/items/catalogueItemsLandingPage.component.tsx
+++ b/src/catalogue/items/catalogueItemsLandingPage.component.tsx
@@ -65,6 +65,9 @@ function CatalogueItemsLandingPage() {
           backgroundColor: 'background.default',
           zIndex: 1000,
           width: '100%',
+          '@media print': {
+            display: 'none',
+          },
         }}
         item
       >

--- a/src/manufacturer/manufacturerLandingPage.component.test.tsx
+++ b/src/manufacturer/manufacturerLandingPage.component.test.tsx
@@ -78,4 +78,22 @@ describe('Manufacturer Landing page', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
   });
+
+  it('prints when the button is clicked', async () => {
+    const spy = jest.spyOn(window, 'print').mockImplementation(() => {});
+    createView('/manufacturer/1');
+
+    await waitFor(() => {
+      expect(screen.getByText('Manufacturer A')).toBeInTheDocument();
+    });
+
+    const printButton = screen.getByRole('button', { name: 'Print' });
+
+    await user.click(printButton);
+    // Assert that the window.print() function was called
+    expect(spy).toHaveBeenCalled();
+
+    // Clean up the mock
+    spy.mockRestore();
+  });
 });

--- a/src/manufacturer/manufacturerLandingPage.component.tsx
+++ b/src/manufacturer/manufacturerLandingPage.component.tsx
@@ -25,7 +25,15 @@ function ManufacturerLandingPage() {
 
   return (
     <Grid container>
-      <Grid sx={{ mx: 0.5 }} item>
+      <Grid
+        sx={{
+          mx: 0.5,
+          '@media print': {
+            display: 'none',
+          },
+        }}
+        item
+      >
         <Button
           component={Link}
           to={`/manufacturer/`}

--- a/src/manufacturer/manufacturerLandingPage.component.tsx
+++ b/src/manufacturer/manufacturerLandingPage.component.tsx
@@ -25,7 +25,7 @@ function ManufacturerLandingPage() {
 
   return (
     <Grid container>
-      <Grid sx={{ padding: '8px' }} item>
+      <Grid sx={{ mx: 0.5 }} item>
         <Button
           component={Link}
           to={`/manufacturer/`}
@@ -36,13 +36,22 @@ function ManufacturerLandingPage() {
         </Button>
         <Button
           disabled={!manufacturerData}
-          sx={{ margin: '8px' }}
+          sx={{ mx: 0.5 }}
           variant="outlined"
           onClick={() => {
             setEditManufacturerDialogOpen(true);
           }}
         >
           Edit
+        </Button>
+        <Button
+          sx={{ mx: 0.5 }}
+          variant="outlined"
+          onClick={() => {
+            window.print();
+          }}
+        >
+          Print
         </Button>
       </Grid>
       {manufacturerData && (


### PR DESCRIPTION
## Description
Add print button on landing page. 
Cypress cannot interact with the browser print dialog. No e2e tests

wait for #144 to add the print button on the manufacturer landing page.
 

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] open browser print dialog 
- [ ] {more steps here}

## Agile board tracking
closes #164
