### PR TITLE
Duplicate property names fix #181

### DIFF
--- a/cypress/e2e/catalogue/catalogueCategory.cy.ts
+++ b/cypress/e2e/catalogue/catalogueCategory.cy.ts
@@ -142,6 +142,37 @@ describe('Catalogue Category', () => {
     });
   });
 
+  it('displays error message when duplicate names for properties are entered', () => {
+    cy.findByRole('button', { name: 'add catalogue category' }).click();
+    cy.findByLabelText('Name *').type('test');
+
+    cy.findByLabelText('Catalogue Items').click();
+
+    cy.startSnoopingBrowserMockedRequest();
+
+    cy.findByRole('button', {
+      name: 'Add catalogue category field entry',
+    }).click();
+
+    cy.findByLabelText('Property Name *').type('Duplicate');
+    cy.findByLabelText('Select Type *').click();
+    cy.findByText('Boolean').click();
+
+    cy.findByRole('button', {
+      name: 'Add catalogue category field entry',
+    }).click();
+
+    cy.findAllByLabelText('Property Name *').last().type('Duplicate');
+    cy.findAllByLabelText('Select Type *').last().click();
+    cy.findByText('Number').click();
+
+    cy.findByRole('button', { name: 'Save' }).click();
+
+    cy.findAllByText(
+      'Duplicate property name. Please change the name or remove the property'
+    ).should('exist');
+  });
+
   it('edits a catalogue category (non leaf node)', () => {
     cy.visit('/catalogue/1');
     cy.findByRole('button', {
@@ -218,6 +249,27 @@ describe('Catalogue Category', () => {
       );
       expect(request.url.toString()).to.contain('1');
     });
+  });
+
+  it('displays error message when duplicate names for properties are entered', () => {
+    cy.visit('/catalogue/1');
+    cy.findByRole('button', {
+      name: 'edit Voltage Meters catalogue category button',
+    }).click();
+
+    cy.startSnoopingBrowserMockedRequest();
+
+    cy.findAllByLabelText('Property Name *').first().clear();
+    cy.findAllByLabelText('Property Name *').first().type('Updated Field');
+
+    cy.findAllByLabelText('Property Name *').last().clear();
+    cy.findAllByLabelText('Property Name *').last().type('Updated Field');
+
+    cy.findByRole('button', { name: 'Save' }).click();
+
+    cy.findAllByText(
+      'Duplicate property name. Please change the name or remove the property'
+    ).should('exist');
   });
 
   it('edits a catalogue category from a leaf node to a non-leaf node ', () => {

--- a/cypress/e2e/catalogue/catalogueCategory.cy.ts
+++ b/cypress/e2e/catalogue/catalogueCategory.cy.ts
@@ -111,7 +111,7 @@ describe('Catalogue Category', () => {
     cy.findByRole('button', {
       name: 'Add catalogue category field entry',
     }).click();
-    cy.findByLabelText('Property Name *').type('Updated Field');
+    cy.findByLabelText('Property Name *').type('Updated Field 1');
     cy.findByLabelText('Select Type *').click();
     cy.findByText('Boolean').click();
 
@@ -124,7 +124,7 @@ describe('Catalogue Category', () => {
     cy.findByText('Property Name is required').should('exist');
     cy.findByText('Select Type is required').should('exist');
 
-    cy.findAllByLabelText('Property Name *').last().type('Updated Field');
+    cy.findAllByLabelText('Property Name *').last().type('Updated Field 2');
     cy.findAllByLabelText('Select Type *').last().click();
     cy.findByText('Number').click();
 
@@ -137,7 +137,7 @@ describe('Catalogue Category', () => {
       expect(patchRequests.length).equal(1);
       const request = patchRequests[0];
       expect(JSON.stringify(request.body)).equal(
-        '{"name":"test","is_leaf":true,"catalogue_item_properties":[{"name":"Updated Field","type":"boolean","mandatory":false},{"name":"Updated Field","type":"number","unit":"","mandatory":false}]}'
+        '{"name":"test","is_leaf":true,"catalogue_item_properties":[{"name":"Updated Field 1","type":"boolean","mandatory":false},{"name":"Updated Field 2","type":"number","unit":"","mandatory":false}]}'
       );
     });
   });

--- a/src/catalogue/category/catalogueCategoryDialog.component.test.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.test.tsx
@@ -288,6 +288,31 @@ describe('Catalogue Category Dialog', () => {
       expect(onClose).not.toHaveBeenCalled();
     });
 
+    it('display error if duplicate property names are entered', async () => {
+      createView();
+      await modifyValues({
+        name: 'test',
+        newFormFields: [
+          { name: 'Field 1', type: 'text', unit: '', mandatory: false },
+          { name: 'Field 2', type: 'number', unit: 'cm', mandatory: true },
+          { name: 'Field 1', type: 'boolean', mandatory: false },
+        ],
+      });
+
+      expect(screen.getByText('Catalogue Item Fields')).toBeInTheDocument();
+
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+
+      await waitFor(() => user.click(saveButton));
+
+      const duplicatePropertyNameHelperText = screen.queryAllByText(
+        'Duplicate property name. Please change the name or remove the property'
+      );
+      expect(duplicatePropertyNameHelperText.length).toBe(2);
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
     it('clears formFields when catalogue content is catalogue categories', async () => {
       createView();
 
@@ -555,6 +580,33 @@ describe('Catalogue Category Dialog', () => {
 
       expect(nameHelperTexts.length).toBe(2);
       expect(typeHelperTexts.length).toBe(2);
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('display error if duplicate property names are entered', async () => {
+      props.selectedCatalogueCategory = {
+        ...mockData,
+        is_leaf: true,
+        catalogue_item_properties: [
+          { name: 'Field 1', type: 'text', unit: '', mandatory: false },
+          { name: 'Field 2', type: 'number', unit: 'cm', mandatory: true },
+          { name: 'Field 1', type: 'boolean', mandatory: false },
+        ],
+      };
+      createView();
+
+      await modifyValues({ name: 'test' });
+      expect(screen.getByText('Catalogue Item Fields')).toBeInTheDocument();
+
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+
+      await user.click(saveButton);
+
+      const duplicatePropertyNameHelperText = screen.queryAllByText(
+        'Duplicate property name. Please change the name or remove the property'
+      );
+      expect(duplicatePropertyNameHelperText.length).toBe(2);
 
       expect(onClose).not.toHaveBeenCalled();
     });

--- a/src/catalogue/category/catalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.tsx
@@ -72,6 +72,10 @@ const CatalogueCategoryDialog = React.memo(
       undefined
     );
 
+    const [duplicatePropertyError, setDuplicatePropertyError] = React.useState<
+      string[] | undefined
+    >(undefined);
+
     const [catchAllError, setCatchAllError] = React.useState(false);
 
     const { mutateAsync: addCatalogueCategory } = useAddCatalogueCategory();
@@ -138,6 +142,7 @@ const CatalogueCategoryDialog = React.memo(
             errorIndexes.push(i);
         }
       }
+      //add error handling here?
 
       setErrorFields(errorIndexes);
       return errorIndexes;
@@ -159,6 +164,29 @@ const CatalogueCategoryDialog = React.memo(
       if (errorIndexes.length !== 0) {
         hasErrors = true;
       }
+
+      if (categoryData.catalogue_item_properties) {
+        const listOfPropertyNames: string[] =
+          categoryData.catalogue_item_properties.map(
+            (property) => property.name
+          );
+        const uniqueNames = new Set();
+        const duplicateNames: string[] = [];
+
+        for (const name of listOfPropertyNames) {
+          if (uniqueNames.has(name)) {
+            duplicateNames.push(name);
+          } else {
+            uniqueNames.add(name);
+          }
+        }
+        if (duplicateNames.length > 0) {
+          setDuplicatePropertyError(duplicateNames);
+          hasErrors = true;
+        }
+      }
+
+      //add error handling here?
       return { hasErrors };
     }, [categoryData, validateFormFields]);
 
@@ -372,6 +400,8 @@ const CatalogueCategoryDialog = React.memo(
                   typeFields={typeFields}
                   onChangeTypeFields={setTypeFields}
                   errorFields={errorFields}
+                  propertyNameError={duplicatePropertyError ?? []}
+                  onChangePropertyNameError={setDuplicatePropertyError}
                   onChangeErrorFields={setErrorFields}
                   resetFormError={() => setFormError(undefined)}
                 />

--- a/src/catalogue/category/catalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.tsx
@@ -73,8 +73,8 @@ const CatalogueCategoryDialog = React.memo(
     );
 
     const [duplicatePropertyError, setDuplicatePropertyError] = React.useState<
-      string[] | undefined
-    >(undefined);
+      string[]
+    >([]);
 
     const [catchAllError, setCatchAllError] = React.useState(false);
 
@@ -400,7 +400,7 @@ const CatalogueCategoryDialog = React.memo(
                   typeFields={typeFields}
                   onChangeTypeFields={setTypeFields}
                   errorFields={errorFields}
-                  propertyNameError={duplicatePropertyError ?? []}
+                  propertyNameError={duplicatePropertyError}
                   onChangePropertyNameError={setDuplicatePropertyError}
                   onChangeErrorFields={setErrorFields}
                   resetFormError={() => setFormError(undefined)}

--- a/src/catalogue/category/catalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.tsx
@@ -167,8 +167,8 @@ const CatalogueCategoryDialog = React.memo(
 
       if (categoryData.catalogue_item_properties) {
         const listOfPropertyNames: string[] =
-          categoryData.catalogue_item_properties.map(
-            (property) => property.name
+          categoryData.catalogue_item_properties.map((property) =>
+            property.name.toLowerCase()
           );
         const uniqueNames = new Set();
         const duplicateNames: string[] = [];

--- a/src/catalogue/category/catalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.tsx
@@ -169,7 +169,7 @@ const CatalogueCategoryDialog = React.memo(
       if (categoryData.catalogue_item_properties) {
         const listOfPropertyNames: string[] =
           categoryData.catalogue_item_properties.map((property) =>
-            property.name.toLowerCase()
+            property.name.toLowerCase().trim()
           );
         const uniqueNames = new Set();
         const duplicateNames: string[] = [];

--- a/src/catalogue/category/cataloguePropertiesForm.component.test.tsx
+++ b/src/catalogue/category/cataloguePropertiesForm.component.test.tsx
@@ -13,6 +13,7 @@ describe('Catalogue Properties Form', () => {
   const onChangeNameFields = jest.fn();
   const onChangeTypeFields = jest.fn();
   const onChangeErrorFields = jest.fn();
+  const onChangePropertyNameError = jest.fn();
   const resetFormError = jest.fn();
   const createView = () => {
     return renderComponentWithBrowserRouter(
@@ -30,6 +31,8 @@ describe('Catalogue Properties Form', () => {
       onChangeTypeFields: onChangeTypeFields,
       errorFields: [],
       onChangeErrorFields: onChangeErrorFields,
+      propertyNameError: [],
+      onChangePropertyNameError: onChangePropertyNameError,
       resetFormError: resetFormError,
     };
     user = userEvent.setup();
@@ -265,5 +268,25 @@ describe('Catalogue Properties Form', () => {
       '',
       'number',
     ]);
+  });
+
+  it('display error if duplicate property names are entered', async () => {
+    const formFields = [
+      { name: 'Field 1', type: 'text', unit: '', mandatory: false },
+      { name: 'Field 2', type: 'number', unit: 'cm', mandatory: true },
+      { name: 'Field 1', type: 'boolean', mandatory: false },
+    ];
+    const propertyNameError = ['Field 1'];
+    props = {
+      ...props,
+      formFields: formFields,
+      propertyNameError: propertyNameError,
+    };
+    createView();
+
+    const duplicatePropertyNameHelperText = screen.queryAllByText(
+      'Duplicate property name. Please change the name or remove the property'
+    );
+    expect(duplicatePropertyNameHelperText.length).toBe(2);
   });
 });

--- a/src/catalogue/category/cataloguePropertiesForm.component.test.tsx
+++ b/src/catalogue/category/cataloguePropertiesForm.component.test.tsx
@@ -219,10 +219,10 @@ describe('Catalogue Properties Form', () => {
     const formFields = [
       { name: '', type: 'number', unit: '', mandatory: false },
       { name: '', type: '', unit: '', mandatory: false },
-      { name: 'raduis', type: '', unit: '', mandatory: false },
-      { name: 'raduis', type: 'number', unit: '', mandatory: false },
+      { name: 'raduis 1', type: '', unit: '', mandatory: false },
+      { name: 'raduis 2', type: 'number', unit: '', mandatory: false },
     ];
-    const nameFields = ['', '', 'raduis', 'raduis'];
+    const nameFields = ['', '', 'raduis 1', 'raduis 2'];
     const typeFields = ['number', '', '', 'number'];
     const errorFields = [0, 1, 2];
     props = {
@@ -259,8 +259,8 @@ describe('Catalogue Properties Form', () => {
     expect(onChangeNameFields).toHaveBeenCalledWith([
       'Updated Field',
       '',
-      'raduis',
-      'raduis',
+      'raduis 1',
+      'raduis 2',
     ]);
     expect(onChangeTypeFields).toHaveBeenCalledWith([
       'boolean',
@@ -270,23 +270,23 @@ describe('Catalogue Properties Form', () => {
     ]);
   });
 
-  // it.only('display error if duplicate property names are entered', async () => {
-  //   const formFields = [
-  //     { name: 'Field', type: 'text', unit: '', mandatory: false },
-  //     { name: 'Field 2', type: 'number', unit: 'cm', mandatory: true },
-  //     { name: 'Field', type: 'boolean', mandatory: false },
-  //   ];
-  //   const propertyNameError = ['Field'];
-  //   props = {
-  //     ...props,
-  //     formFields: formFields,
-  //     propertyNameError: propertyNameError,
-  //   };
-  //   createView();
+  it('display error if duplicate property names are entered', async () => {
+    const formFields = [
+      { name: 'Field', type: 'text', unit: '', mandatory: false },
+      { name: 'Field 2', type: 'number', unit: 'cm', mandatory: true },
+      { name: 'Field', type: 'boolean', mandatory: false },
+    ];
+    const propertyNameError = ['field'];
+    props = {
+      ...props,
+      formFields: formFields,
+      propertyNameError: propertyNameError,
+    };
+    createView();
 
-  //   const duplicatePropertyNameHelperText = screen.queryAllByText(
-  //     'Duplicate property name. Please change the name or remove the property'
-  //   );
-  //   expect(duplicatePropertyNameHelperText.length).toBe(2);
-  // });
+    const duplicatePropertyNameHelperText = screen.queryAllByText(
+      'Duplicate property name. Please change the name or remove the property'
+    );
+    expect(duplicatePropertyNameHelperText.length).toBe(2);
+  });
 });

--- a/src/catalogue/category/cataloguePropertiesForm.component.test.tsx
+++ b/src/catalogue/category/cataloguePropertiesForm.component.test.tsx
@@ -270,23 +270,23 @@ describe('Catalogue Properties Form', () => {
     ]);
   });
 
-  it('display error if duplicate property names are entered', async () => {
-    const formFields = [
-      { name: 'Field 1', type: 'text', unit: '', mandatory: false },
-      { name: 'Field 2', type: 'number', unit: 'cm', mandatory: true },
-      { name: 'Field 1', type: 'boolean', mandatory: false },
-    ];
-    const propertyNameError = ['Field 1'];
-    props = {
-      ...props,
-      formFields: formFields,
-      propertyNameError: propertyNameError,
-    };
-    createView();
+  // it.only('display error if duplicate property names are entered', async () => {
+  //   const formFields = [
+  //     { name: 'Field', type: 'text', unit: '', mandatory: false },
+  //     { name: 'Field 2', type: 'number', unit: 'cm', mandatory: true },
+  //     { name: 'Field', type: 'boolean', mandatory: false },
+  //   ];
+  //   const propertyNameError = ['Field'];
+  //   props = {
+  //     ...props,
+  //     formFields: formFields,
+  //     propertyNameError: propertyNameError,
+  //   };
+  //   createView();
 
-    const duplicatePropertyNameHelperText = screen.queryAllByText(
-      'Duplicate property name. Please change the name or remove the property'
-    );
-    expect(duplicatePropertyNameHelperText.length).toBe(2);
-  });
+  //   const duplicatePropertyNameHelperText = screen.queryAllByText(
+  //     'Duplicate property name. Please change the name or remove the property'
+  //   );
+  //   expect(duplicatePropertyNameHelperText.length).toBe(2);
+  // });
 });

--- a/src/catalogue/category/cataloguePropertiesForm.component.tsx
+++ b/src/catalogue/category/cataloguePropertiesForm.component.tsx
@@ -22,6 +22,8 @@ export interface CataloguePropertiesFormProps {
   onChangeTypeFields: (typeFields: string[]) => void;
   errorFields: number[];
   onChangeErrorFields: (errorFields: number[]) => void;
+  propertyNameError: string[];
+  onChangePropertyNameError: (propertyNameError: string[]) => void;
   resetFormError: () => void;
 }
 
@@ -35,6 +37,8 @@ function CataloguePropertiesForm(props: CataloguePropertiesFormProps) {
     onChangeTypeFields,
     errorFields,
     onChangeErrorFields,
+    propertyNameError,
+    onChangePropertyNameError,
     resetFormError,
   } = props;
 
@@ -100,6 +104,8 @@ function CataloguePropertiesForm(props: CataloguePropertiesFormProps) {
     resetFormError();
   };
 
+  console.log(propertyNameError);
+
   return (
     <div>
       {formFields.map((field, index) => (
@@ -111,10 +117,21 @@ function CataloguePropertiesForm(props: CataloguePropertiesFormProps) {
             required={true}
             value={field.name}
             onChange={(e) => handleChange(index, 'name', e.target.value)}
-            error={errorFields.includes(index) && !nameFields[index].trim()}
+            error={
+              (errorFields.includes(index) && !nameFields[index].trim()) ||
+              (propertyNameError.length !== 0 &&
+                propertyNameError.find((name) => {
+                  return name === field.name;
+                }) === field.name)
+            }
             helperText={
               errorFields.includes(index) && !nameFields[index].trim()
                 ? 'Property Name is required'
+                : propertyNameError.length !== 0 &&
+                  propertyNameError.find((name) => {
+                    return name === field.name;
+                  }) === field.name
+                ? 'Duplicate property name. Please change the name or remove the property'
                 : ''
             }
             sx={{ minWidth: '150px' }}

--- a/src/catalogue/category/cataloguePropertiesForm.component.tsx
+++ b/src/catalogue/category/cataloguePropertiesForm.component.tsx
@@ -104,8 +104,6 @@ function CataloguePropertiesForm(props: CataloguePropertiesFormProps) {
     resetFormError();
   };
 
-  console.log(propertyNameError);
-
   return (
     <div>
       {formFields.map((field, index) => (
@@ -121,16 +119,16 @@ function CataloguePropertiesForm(props: CataloguePropertiesFormProps) {
               (errorFields.includes(index) && !nameFields[index].trim()) ||
               (propertyNameError.length !== 0 &&
                 propertyNameError.find((name) => {
-                  return name === field.name;
-                }) === field.name)
+                  return name === field.name.toLowerCase();
+                }) === field.name.toLowerCase())
             }
             helperText={
               errorFields.includes(index) && !nameFields[index].trim()
                 ? 'Property Name is required'
                 : propertyNameError.length !== 0 &&
                   propertyNameError.find((name) => {
-                    return name === field.name;
-                  }) === field.name
+                    return name === field.name.toLowerCase();
+                  }) === field.name.toLowerCase()
                 ? 'Duplicate property name. Please change the name or remove the property'
                 : ''
             }

--- a/src/catalogue/category/cataloguePropertiesForm.component.tsx
+++ b/src/catalogue/category/cataloguePropertiesForm.component.tsx
@@ -68,6 +68,7 @@ function CataloguePropertiesForm(props: CataloguePropertiesFormProps) {
     onChangeFormFields(updatedFormFields);
     onChangeNameFields(updatedNameFields);
     onChangeTypeFields(updatedTypeFields);
+    onChangePropertyNameError([]);
     resetFormError();
   };
 
@@ -120,16 +121,16 @@ function CataloguePropertiesForm(props: CataloguePropertiesFormProps) {
               (errorFields.includes(index) && !nameFields[index].trim()) ||
               (propertyNameError.length !== 0 &&
                 propertyNameError.find((name) => {
-                  return name === field.name.toLowerCase();
-                }) === field.name.toLowerCase())
+                  return name === field.name.toLowerCase().trim();
+                }) === field.name.toLowerCase().trim())
             }
             helperText={
               errorFields.includes(index) && !nameFields[index].trim()
                 ? 'Property Name is required'
                 : propertyNameError.length !== 0 &&
                   propertyNameError.find((name) => {
-                    return name === field.name.toLowerCase();
-                  }) === field.name.toLowerCase()
+                    return name === field.name.toLowerCase().trim();
+                  }) === field.name.toLowerCase().trim()
                 ? 'Duplicate property name. Please change the name or remove the property'
                 : ''
             }


### PR DESCRIPTION
## Description

Implemented logic to prevent duplicate catalogue item property names to be used when creating a catalogue category. Check is not case sensitive so will detect words which are the same (regardless of capitalization). Error messages appear on the properties with duplicate names, and all disappear when an value is changed. Logic works for both adding and editing a catalogue category

## Testing instructions


- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] check works for creating a catalogue category
- [ ] check works for editing a catalogue category

## Agile board tracking

closes #181
