### PR TITLE
Disable buttons on error #187

### DIFF
--- a/cypress/e2e/catalogue/catalogueCategory.cy.ts
+++ b/cypress/e2e/catalogue/catalogueCategory.cy.ts
@@ -43,6 +43,7 @@ describe('Catalogue Category', () => {
           'A catalogue category with the same name already exists within the parent catalogue category'
         );
       });
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
   });
 
   it('adds a catalogue category where isLeaf is false', () => {
@@ -79,6 +80,7 @@ describe('Catalogue Category', () => {
           'Catalogue category has children elements and cannot be deleted, please delete the children elements first'
         );
       });
+    cy.findByRole('button', { name: 'Continue' }).should('be.disabled');
   });
 
   it('delete a catalogue category', () => {
@@ -176,6 +178,7 @@ describe('Catalogue Category', () => {
       .within(() => {
         cy.contains('Please edit a form entry before clicking save');
       });
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
   });
 
   it('displays error message if it received an unknown error from the api', () => {
@@ -193,7 +196,9 @@ describe('Catalogue Category', () => {
       .within(() => {
         cy.contains('Please refresh and try again');
       });
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
   });
+
   it('edits a catalogue category with catalogue properties', () => {
     cy.visit('/catalogue/1');
     cy.findByRole('button', {

--- a/cypress/e2e/catalogue/catalogueItems.cy.ts
+++ b/cypress/e2e/catalogue/catalogueItems.cy.ts
@@ -109,6 +109,7 @@ describe('Catalogue Items', () => {
       'Please choose a manufacturer, or add a new manufacturer'
     ).should('exist');
     cy.findByText('Please select either True or False').should('exist');
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
 
     cy.findByLabelText('Name *').type('test');
     cy.findByLabelText('Resolution (megapixels) *').type('18');
@@ -143,12 +144,12 @@ describe('Catalogue Items', () => {
     cy.findByRole('button', { name: 'Save' }).click();
 
     cy.findAllByText('Please enter a valid number').should('have.length', 4);
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
 
     cy.findByLabelText('Resolution (megapixels) *').clear();
     cy.findByLabelText('Resolution (megapixels) *').type('12');
     cy.findByLabelText('Frame Rate (fps)').clear();
     cy.findByLabelText('Frame Rate (fps)').type('12');
-    cy.findByLabelText('Resolution (megapixels) *').clear();
     cy.findByLabelText('Cost (£) *').clear();
     cy.findByLabelText('Cost (£) *').type('5000');
     cy.findByLabelText('Time to replace (days) *').clear();
@@ -162,6 +163,7 @@ describe('Catalogue Items', () => {
     cy.findAllByText(
       'Please enter a valid Drawing link. Only "http://" and "https://" links with typical top-level domain are accepted'
     ).should('exist');
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
 
     cy.findByLabelText('Drawing link').clear();
 
@@ -304,6 +306,7 @@ describe('Catalogue Items', () => {
           'Catalogue item has children elements and cannot be deleted, please delete the children elements first'
         );
       });
+    cy.findByRole('button', { name: 'Continue' }).should('be.disabled');
   });
 
   it('delete a catalogue item', () => {
@@ -331,6 +334,12 @@ describe('Catalogue Items', () => {
     cy.findByText('Edit').click();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog')
+      .should('be.visible')
+      .within(() => {
+        cy.contains('Please edit a form entry before clicking save');
+      });
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
   });
 
   it('displays error message if catalogue item has children elements', () => {
@@ -351,6 +360,7 @@ describe('Catalogue Items', () => {
           'Catalogue item has children elements and cannot be edited, please delete the children elements first'
         );
       });
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
   });
 
   it('edit a catalogue item (Catalogue item details)', () => {

--- a/cypress/e2e/manufacturer/manufacturer.cy.ts
+++ b/cypress/e2e/manufacturer/manufacturer.cy.ts
@@ -177,6 +177,7 @@ describe('Manufacturer', () => {
           'The specified manufacturer is a part of a Catalogue Item. Please delete the Catalogue Item first.'
         );
       });
+    cy.findByRole('button', { name: 'Continue' }).should('be.disabled');
   });
   it('Edits a manufacturer correctly', () => {
     cy.visit('/manufacturer');
@@ -235,6 +236,7 @@ describe('Manufacturer', () => {
           'A manufacturer with the same name has been found. Please enter a different name'
         );
       });
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
   });
 
   it('Trying to edit with invalid url displays error message', () => {
@@ -251,6 +253,7 @@ describe('Manufacturer', () => {
       .within(() => {
         cy.contains('Please enter a valid URL');
       });
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
   });
 
   it('Not changing any fields shows error', () => {
@@ -266,6 +269,7 @@ describe('Manufacturer', () => {
           "There have been no changes made. Please change a field's value or press Cancel to exit"
         );
       });
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
   });
 
   it('Required fields that are cleared are not allowed and show error message', () => {
@@ -298,6 +302,7 @@ describe('Manufacturer', () => {
       .within(() => {
         cy.contains('Please enter a post code or zip code.');
       });
+    cy.findByRole('button', { name: 'Save' }).should('be.disabled');
   });
 
   it('navigates to landing page and navigates back to the table view', () => {

--- a/cypress/e2e/system.cy.ts
+++ b/cypress/e2e/system.cy.ts
@@ -137,7 +137,7 @@ describe('System', () => {
       cy.findByRole('button', { name: 'add system' }).click();
       cy.findByRole('button', { name: 'Save' }).click();
       cy.findByText('Please enter a name').should('be.visible');
-      cy.findByRole('button', { name: 'Save' }).click();
+      cy.findByRole('button', { name: 'Save' }).should('be.disabled');
       cy.findByRole('button', { name: 'Cancel' }).click();
       cy.findByRole('button', { name: 'add system' }).click();
       cy.findByText('Please enter a name').should('not.exist');
@@ -152,6 +152,7 @@ describe('System', () => {
       cy.findByText(
         'A System with the same name already exists within the same parent System'
       ).should('be.visible');
+      cy.findByRole('button', { name: 'Save' }).should('be.disabled');
       cy.findByRole('button', { name: 'Cancel' }).click();
       cy.findByRole('button', { name: 'add system' }).click();
       cy.findByText(
@@ -166,6 +167,7 @@ describe('System', () => {
       cy.findByLabelText('Name *').type('Error 500');
       cy.findByRole('button', { name: 'Save' }).click();
       cy.findByText('Please refresh and try again').should('be.visible');
+      cy.findByRole('button', { name: 'Save' }).should('be.disabled');
       cy.findByRole('button', { name: 'Cancel' }).click();
       cy.findByRole('button', { name: 'add system' }).click();
       cy.findByText('Please refresh and try again').should('not.exist');
@@ -237,6 +239,7 @@ describe('System', () => {
       cy.findByText('Please edit a form entry before clicking save').should(
         'be.visible'
       );
+      cy.findByRole('button', { name: 'Save' }).should('be.disabled');
       cy.findByLabelText('Description').type('1');
       cy.findByText('Please edit a form entry before clicking save').should(
         'not.exist'
@@ -251,7 +254,7 @@ describe('System', () => {
       cy.findByLabelText('Name *').clear();
       cy.findByRole('button', { name: 'Save' }).click();
       cy.findByText('Please enter a name').should('be.visible');
-      cy.findByRole('button', { name: 'Save' }).click();
+      cy.findByRole('button', { name: 'Save' }).should('be.disabled');
       cy.findByRole('button', { name: 'Cancel' }).click();
       cy.findByRole('button', { name: 'Edit System' }).click();
       cy.findByText('Please enter a name').should('not.exist');
@@ -267,6 +270,7 @@ describe('System', () => {
       cy.findByText(
         'A System with the same name already exists within the same parent System'
       ).should('be.visible');
+      cy.findByRole('button', { name: 'Save' }).should('be.disabled');
       cy.findByRole('button', { name: 'Cancel' }).click();
       cy.findByRole('button', { name: 'Edit System' }).click();
       cy.findByText(
@@ -282,6 +286,7 @@ describe('System', () => {
       cy.findByLabelText('Name *').clear().type('Error 500');
       cy.findByRole('button', { name: 'Save' }).click();
       cy.findByText('Please refresh and try again').should('be.visible');
+      cy.findByRole('button', { name: 'Save' }).should('be.disabled');
       cy.findByRole('button', { name: 'Cancel' }).click();
       cy.findByRole('button', { name: 'Edit System' }).click();
       cy.findByText('Please refresh and try again').should('not.exist');
@@ -320,6 +325,7 @@ describe('System', () => {
           'System has child elements and cannot be deleted, please delete the child systems first'
         ).should('be.visible');
       });
+    cy.findByRole('button', { name: 'Continue' }).should('be.disabled');
 
     cy.findByRole('button', { name: 'Cancel' }).click();
     cy.findByRole('button', { name: 'Delete System' }).click();

--- a/src/catalogue/category/catalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.tsx
@@ -406,6 +406,11 @@ const CatalogueCategoryDialog = React.memo(
                   ? handleAddCatalogueCategory
                   : handleEditCatalogueCategory
               }
+              disabled={
+                formError !== undefined ||
+                catchAllError ||
+                nameError !== undefined
+              }
             >
               Save
             </Button>

--- a/src/catalogue/category/catalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.tsx
@@ -409,7 +409,8 @@ const CatalogueCategoryDialog = React.memo(
               disabled={
                 formError !== undefined ||
                 catchAllError ||
-                nameError !== undefined
+                nameError !== undefined ||
+                errorFields.length !== 0
               }
             >
               Save

--- a/src/catalogue/category/cataloguePropertiesForm.component.tsx
+++ b/src/catalogue/category/cataloguePropertiesForm.component.tsx
@@ -97,6 +97,7 @@ function CataloguePropertiesForm(props: CataloguePropertiesFormProps) {
     onChangeFormFields(updatedFormFields);
     onChangeNameFields(updatedNameFields);
     onChangeTypeFields(updatedTypeFields);
+    onChangeErrorFields([]);
     resetFormError();
   };
 

--- a/src/catalogue/category/deleteCatalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/deleteCatalogueCategoryDialog.component.tsx
@@ -80,7 +80,9 @@ const DeleteCatalogueCategoryDialog = (
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleDeleteCatalogueCategory}>Continue</Button>
+        <Button onClick={handleDeleteCatalogueCategory} disabled={error}>
+          Continue
+        </Button>
       </DialogActions>
       {error && (
         <Box

--- a/src/catalogue/items/catalogueItemsDialog.component.tsx
+++ b/src/catalogue/items/catalogueItemsDialog.component.tsx
@@ -106,7 +106,6 @@ function CatalogueItemsDialog(props: CatalogueItemsDialogProps) {
   const [propertyErrors, setPropertyErrors] = React.useState(
     new Array(parentCatalogueItemPropertiesInfo.length).fill(false)
   );
-
   // set the errors as the types into the input fields
 
   const [errorMessages, setErrorMessages] = React.useState<
@@ -987,6 +986,14 @@ function CatalogueItemsDialog(props: CatalogueItemsDialogProps) {
             sx={{ width: '50%', mx: 1 }}
             onClick={
               type === 'edit' ? handleEditCatalogueItem : handleAddCatalogueItem
+            }
+            disabled={
+              JSON.stringify(errorMessages) !== '{}' ||
+              catchAllError ||
+              formError ||
+              propertyErrors.some((value) => {
+                return value === true;
+              })
             }
           >
             Save

--- a/src/catalogue/items/deleteCatalogueItemDialog.component.tsx
+++ b/src/catalogue/items/deleteCatalogueItemDialog.component.tsx
@@ -69,7 +69,9 @@ const DeleteCatalogueItemDialog = (props: DeleteCatalogueItemDialogProps) => {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleDeleteCatalogueCategory}>Continue</Button>
+        <Button onClick={handleDeleteCatalogueCategory} disabled={error}>
+          Continue
+        </Button>
       </DialogActions>
       {error && (
         <Box

--- a/src/catalogue/items/obsoleteCatalogueItemDialog.component.tsx
+++ b/src/catalogue/items/obsoleteCatalogueItemDialog.component.tsx
@@ -325,7 +325,12 @@ const ObsoleteCatalogueItemDialog = (
           Back
         </Button>
         {activeStep === steps.length - 1 ? (
-          <Button onClick={handleFinish}>Finish</Button>
+          <Button
+            onClick={handleFinish}
+            disabled={formError !== undefined || otherError}
+          >
+            Finish
+          </Button>
         ) : (
           <Button onClick={handleNext}>Next</Button>
         )}

--- a/src/manufacturer/deleteManufacturerDialog.component.tsx
+++ b/src/manufacturer/deleteManufacturerDialog.component.tsx
@@ -70,7 +70,9 @@ const DeleteManufacturerDialog = (props: DeleteManufacturerProps) => {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleDeleteManufacturer}>Continue</Button>
+        <Button onClick={handleDeleteManufacturer} disabled={error}>
+          Continue
+        </Button>
       </DialogActions>
       {error && (
         <Box

--- a/src/manufacturer/manufacturerDialog.component.tsx
+++ b/src/manufacturer/manufacturerDialog.component.tsx
@@ -552,6 +552,15 @@ function ManufacturerDialog(props: ManufacturerDialogProps) {
                 ? handleAddManufacturer
                 : handleEditManufacturer
             }
+            disabled={
+              formError ||
+              catchAllError ||
+              nameError ||
+              urlError ||
+              addressLineError ||
+              addressPostcodeError ||
+              countryError
+            }
           >
             Save
           </Button>

--- a/src/systems/deleteSystemDialog.component.tsx
+++ b/src/systems/deleteSystemDialog.component.tsx
@@ -64,7 +64,12 @@ export const DeleteSystemDialog = (props: DeleteSystemDialogProps) => {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleDeleteSystem}>Continue</Button>
+        <Button
+          onClick={handleDeleteSystem}
+          disabled={errorMessage !== undefined}
+        >
+          Continue
+        </Button>
       </DialogActions>
       {errorMessage !== undefined && (
         <Box

--- a/src/systems/systemDialog.component.tsx
+++ b/src/systems/systemDialog.component.tsx
@@ -226,6 +226,7 @@ const SystemDialog = React.memo((props: SystemDialogProps) => {
               helperText={nameError}
               onChange={(event) => {
                 handleFormChange({ ...systemData, name: event.target.value });
+                setNameError(undefined);
               }}
               fullWidth
             />
@@ -317,6 +318,9 @@ const SystemDialog = React.memo((props: SystemDialogProps) => {
             variant="outlined"
             sx={{ width: '50%', mx: 1 }}
             onClick={type === 'add' ? handleAddSystem : handleEditSystem}
+            disabled={
+              formError !== undefined || otherError || nameError !== undefined
+            }
           >
             Save
           </Button>


### PR DESCRIPTION
## Description

Implemented logic so that save/continue buttons in the dialogs are disabled if there is an error in the dialog.
I only refactored the e2e tests that test for errors, to check if the save/continue button is disabled

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
## Agile board tracking

closes #187
