### PR TITLE
save-as-for-catalogue-categories-#172

### DIFF
--- a/cypress/e2e/catalogue/catalogueCategory.cy.ts
+++ b/cypress/e2e/catalogue/catalogueCategory.cy.ts
@@ -66,17 +66,50 @@ describe('Catalogue Category', () => {
     });
   });
 
-  it('opens actions menu', () => {
+  it('opens actions menu and then closes', () => {
     cy.findByRole('button', {
       name: 'actions Motion catalogue category button',
     }).click();
 
     cy.findByRole('menuitem', {
-      name: 'delete Motion catalogue category button',
+      name: 'edit Motion catalogue category button',
+    }).should('be.visible');
+    cy.findByRole('menuitem', {
+      name: 'save as Motion catalogue category button',
     }).should('be.visible');
     cy.findByRole('menuitem', {
       name: 'delete Motion catalogue category button',
+    })
+      .should('be.visible')
+      .click();
+
+    cy.findByText('Cancel').click();
+
+    cy.findByRole('button', {
+      name: 'actions Motion catalogue category button',
     }).should('be.visible');
+  });
+
+  it('"save as" a catalogue category', () => {
+    cy.findByRole('button', {
+      name: 'actions Motion catalogue category button',
+    }).click();
+    cy.findByText('Save as').click();
+
+    cy.startSnoopingBrowserMockedRequest();
+
+    cy.findByRole('button', { name: 'Save' }).click();
+
+    cy.findBrowserMockedRequests({
+      method: 'POST',
+      url: '/v1/catalogue-categories',
+    }).should((patchRequests) => {
+      expect(patchRequests.length).equal(1);
+      const request = patchRequests[0];
+      expect(JSON.stringify(request.body)).equal(
+        '{"name":"Motion_copy_1","is_leaf":false}'
+      );
+    });
   });
 
   it('displays error message when user tries to delete a catalogue category that has children elements', () => {

--- a/cypress/e2e/catalogue/catalogueCategory.cy.ts
+++ b/cypress/e2e/catalogue/catalogueCategory.cy.ts
@@ -66,8 +66,25 @@ describe('Catalogue Category', () => {
     });
   });
 
+  it('opens actions menu', () => {
+    cy.findByRole('button', {
+      name: 'actions Motion catalogue category button',
+    }).click();
+
+    cy.findByRole('menuitem', {
+      name: 'delete Motion catalogue category button',
+    }).should('be.visible');
+    cy.findByRole('menuitem', {
+      name: 'delete Motion catalogue category button',
+    }).should('be.visible');
+  });
+
   it('displays error message when user tries to delete a catalogue category that has children elements', () => {
     cy.findByRole('button', {
+      name: 'actions Motion catalogue category button',
+    }).click();
+
+    cy.findByRole('menuitem', {
       name: 'delete Motion catalogue category button',
     }).click();
 
@@ -85,6 +102,10 @@ describe('Catalogue Category', () => {
 
   it('delete a catalogue category', () => {
     cy.findByRole('button', {
+      name: 'actions Beam Characterization catalogue category button',
+    }).click();
+
+    cy.findByRole('menuitem', {
       name: 'delete Beam Characterization catalogue category button',
     }).click();
 
@@ -178,6 +199,10 @@ describe('Catalogue Category', () => {
   it('edits a catalogue category (non leaf node)', () => {
     cy.visit('/catalogue/1');
     cy.findByRole('button', {
+      name: 'actions Amp Meters catalogue category button',
+    }).click();
+
+    cy.findByRole('menuitem', {
       name: 'edit Amp Meters catalogue category button',
     }).click();
     cy.findByLabelText('Name *').type('1');
@@ -199,6 +224,10 @@ describe('Catalogue Category', () => {
 
   it('displays error message if none of the fields have changed', () => {
     cy.findByRole('button', {
+      name: 'actions Beam Characterization catalogue category button',
+    }).click();
+
+    cy.findByRole('menuitem', {
       name: 'edit Beam Characterization catalogue category button',
     }).click();
 
@@ -215,6 +244,10 @@ describe('Catalogue Category', () => {
   it('displays error message if it received an unknown error from the api', () => {
     cy.visit('/catalogue/1');
     cy.findByRole('button', {
+      name: 'actions Cameras catalogue category button',
+    }).click();
+
+    cy.findByRole('menuitem', {
       name: 'edit Cameras catalogue category button',
     }).click();
     cy.findByLabelText('Name *').clear();
@@ -233,6 +266,10 @@ describe('Catalogue Category', () => {
   it('edits a catalogue category with catalogue properties', () => {
     cy.visit('/catalogue/1');
     cy.findByRole('button', {
+      name: 'actions Voltage Meters catalogue category button',
+    }).click();
+
+    cy.findByRole('menuitem', {
       name: 'edit Voltage Meters catalogue category button',
     }).click();
 
@@ -259,6 +296,10 @@ describe('Catalogue Category', () => {
   it('displays error message when duplicate names for properties are entered', () => {
     cy.visit('/catalogue/1');
     cy.findByRole('button', {
+      name: 'actions Voltage Meters catalogue category button',
+    }).click();
+
+    cy.findByRole('menuitem', {
       name: 'edit Voltage Meters catalogue category button',
     }).click();
 
@@ -280,6 +321,10 @@ describe('Catalogue Category', () => {
   it('edits a catalogue category from a leaf node to a non-leaf node ', () => {
     cy.visit('/catalogue/1');
     cy.findByRole('button', {
+      name: 'actions Voltage Meters catalogue category button',
+    }).click();
+
+    cy.findByRole('menuitem', {
       name: 'edit Voltage Meters catalogue category button',
     }).click();
     cy.findByLabelText('Catalogue Categories').click();

--- a/src/catalogue/catalogue.component.test.tsx
+++ b/src/catalogue/catalogue.component.test.tsx
@@ -236,7 +236,12 @@ describe('Catalogue', () => {
       expect(screen.getByText('Beam Characterization')).toBeInTheDocument();
     });
 
-    const deleteButton = screen.getByRole('button', {
+    const actionsButton = screen.getByRole('button', {
+      name: 'actions Beam Characterization catalogue category button',
+    });
+    await user.click(actionsButton);
+
+    const deleteButton = screen.getByRole('menuitem', {
       name: 'delete Beam Characterization catalogue category button',
     });
     await user.click(deleteButton);
@@ -259,7 +264,12 @@ describe('Catalogue', () => {
       expect(screen.getByText('Amp Meters')).toBeInTheDocument();
     });
 
-    const editButton = screen.getByRole('button', {
+    const actionsButton = screen.getByRole('button', {
+      name: 'actions Amp Meters catalogue category button',
+    });
+    await user.click(actionsButton);
+
+    const editButton = screen.getByRole('menuitem', {
       name: 'edit Amp Meters catalogue category button',
     });
     await user.click(editButton);

--- a/src/catalogue/catalogue.component.test.tsx
+++ b/src/catalogue/catalogue.component.test.tsx
@@ -287,6 +287,36 @@ describe('Catalogue', () => {
     });
   });
 
+  it('opens the save as catalogue category dialog', async () => {
+    createView('/catalogue/1');
+
+    await waitFor(() => {
+      expect(screen.getByText('Amp Meters')).toBeInTheDocument();
+    });
+
+    const actionsButton = screen.getByRole('button', {
+      name: 'actions Amp Meters catalogue category button',
+    });
+    await user.click(actionsButton);
+
+    const editButton = screen.getByRole('menuitem', {
+      name: 'save as Amp Meters catalogue category button',
+    });
+    await user.click(editButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+
+    await user.type(screen.getByLabelText('Name *'), '1');
+    await user.click(saveButton);
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
   it('renders the breadcrumbs and navigate to another directory', async () => {
     createView('/catalogue/8');
 

--- a/src/catalogue/catalogue.component.test.tsx
+++ b/src/catalogue/catalogue.component.test.tsx
@@ -287,7 +287,7 @@ describe('Catalogue', () => {
     });
   });
 
-  it('opens the save as catalogue category dialog', async () => {
+  it('can open the save as catalogue category dialog and close it again', async () => {
     createView('/catalogue/1');
 
     await waitFor(() => {

--- a/src/catalogue/catalogue.component.tsx
+++ b/src/catalogue/catalogue.component.tsx
@@ -29,6 +29,7 @@ import CatalogueCategoryDialog from './category/catalogueCategoryDialog.componen
 import CatalogueCategoryDirectoryDialog from './category/catalogueCategoryDirectoryDialog.component';
 import DeleteCatalogueCategoryDialog from './category/deleteCatalogueCategoryDialog.component';
 import CatalogueItemsTable from './items/catalogueItemsTable.component';
+import { generateUniqueName } from '../utils';
 
 export interface AddCatalogueButtonProps {
   disabled: boolean;
@@ -63,20 +64,20 @@ const AddCategoryButton = (props: AddCatalogueButtonProps) => {
   );
 };
 
-function generateUniqueName(
-  existingNames: (string | undefined)[],
-  originalName: string
-) {
-  let newName = originalName;
-  let copyIndex = 1;
+// function generateUniqueName(
+//   existingNames: (string | undefined)[],
+//   originalName: string
+// ) {
+//   let newName = originalName;
+//   let copyIndex = 1;
 
-  while (existingNames.includes(newName)) {
-    newName = `${originalName}_copy_${copyIndex}`;
-    copyIndex++;
-  }
+//   while (existingNames.includes(newName)) {
+//     newName = `${originalName}_copy_${copyIndex}`;
+//     copyIndex++;
+//   }
 
-  return newName;
-}
+//   return newName;
+// }
 
 export function matchCatalogueItemProperties(
   form: CatalogueCategoryFormData[],
@@ -144,7 +145,7 @@ function Catalogue() {
     !catalogueId ? 'null' : catalogueId.replace('/', '')
   );
 
-  const catalogueCategoryNames: (string | undefined)[] =
+  const catalogueCategoryNames: string[] =
     catalogueCategoryData?.map((item) => item.name) || [];
 
   const [deleteCategoryDialogOpen, setDeleteCategoryDialogOpen] =
@@ -363,8 +364,8 @@ function Catalogue() {
             ? {
                 ...selectedCatalogueCategory,
                 name: generateUniqueName(
-                  catalogueCategoryNames,
-                  selectedCatalogueCategory.name
+                  selectedCatalogueCategory.name,
+                  catalogueCategoryNames
                 ),
               }
             : undefined

--- a/src/catalogue/catalogue.component.tsx
+++ b/src/catalogue/catalogue.component.tsx
@@ -64,21 +64,6 @@ const AddCategoryButton = (props: AddCatalogueButtonProps) => {
   );
 };
 
-// function generateUniqueName(
-//   existingNames: (string | undefined)[],
-//   originalName: string
-// ) {
-//   let newName = originalName;
-//   let copyIndex = 1;
-
-//   while (existingNames.includes(newName)) {
-//     newName = `${originalName}_copy_${copyIndex}`;
-//     copyIndex++;
-//   }
-
-//   return newName;
-// }
-
 export function matchCatalogueItemProperties(
   form: CatalogueCategoryFormData[],
   items: CatalogueItemProperty[]

--- a/src/catalogue/catalogue.component.tsx
+++ b/src/catalogue/catalogue.component.tsx
@@ -63,6 +63,21 @@ const AddCategoryButton = (props: AddCatalogueButtonProps) => {
   );
 };
 
+function generateUniqueName(
+  existingNames: (string | undefined)[],
+  originalName: string
+) {
+  let newName = originalName;
+  let copyIndex = 1;
+
+  while (existingNames.includes(newName)) {
+    newName = `${originalName}_copy_${copyIndex}`;
+    copyIndex++;
+  }
+
+  return newName;
+}
+
 export function matchCatalogueItemProperties(
   form: CatalogueCategoryFormData[],
   items: CatalogueItemProperty[]
@@ -128,6 +143,9 @@ function Catalogue() {
     catalogueCategoryDetailLoading ? true : !!parentInfo && parentInfo.is_leaf,
     !catalogueId ? 'null' : catalogueId.replace('/', '')
   );
+
+  const catalogueCategoryNames: (string | undefined)[] =
+    catalogueCategoryData?.map((item) => item.name) || [];
 
   const [deleteCategoryDialogOpen, setDeleteCategoryDialogOpen] =
     React.useState<boolean>(false);
@@ -340,7 +358,17 @@ function Catalogue() {
         onClose={() => setSaveAsCategoryDialogOpen(false)}
         parentId={parentId}
         type="save as"
-        selectedCatalogueCategory={selectedCatalogueCategory}
+        selectedCatalogueCategory={
+          selectedCatalogueCategory
+            ? {
+                ...selectedCatalogueCategory,
+                name: generateUniqueName(
+                  catalogueCategoryNames,
+                  selectedCatalogueCategory.name
+                ),
+              }
+            : undefined
+        }
         resetSelectedCatalogueCategory={() =>
           setSelectedCatalogueCategory(undefined)
         }

--- a/src/catalogue/catalogue.component.tsx
+++ b/src/catalogue/catalogue.component.tsx
@@ -135,6 +135,9 @@ function Catalogue() {
   const [editCategoryDialogOpen, setEditCategoryDialogOpen] =
     React.useState<boolean>(false);
 
+  const [saveAsCategoryDialogOpen, setSaveAsCategoryDialogOpen] =
+    React.useState<boolean>(false);
+
   const [selectedCatalogueCategory, setSelectedCatalogueCategory] =
     React.useState<CatalogueCategory | undefined>(undefined);
 
@@ -149,6 +152,11 @@ function Catalogue() {
     catalogueCategory: CatalogueCategory
   ) => {
     setEditCategoryDialogOpen(true);
+    setSelectedCatalogueCategory(catalogueCategory);
+  };
+
+  const onChangeOpenSaveAsDialog = (catalogueCategory: CatalogueCategory) => {
+    setSaveAsCategoryDialogOpen(true);
     setSelectedCatalogueCategory(catalogueCategory);
   };
 
@@ -302,6 +310,7 @@ function Catalogue() {
                   {...item}
                   onChangeOpenDeleteDialog={onChangeOpenDeleteCategoryDialog}
                   onChangeOpenEditDialog={onChangeOpenEditCategoryDialog}
+                  onChangeOpenSaveAsDialog={onChangeOpenSaveAsDialog}
                   onToggleSelect={handleToggleSelect}
                   isSelected={selectedCategories.some(
                     (selectedCategory: CatalogueCategory) =>
@@ -321,6 +330,16 @@ function Catalogue() {
         onClose={() => setEditCategoryDialogOpen(false)}
         parentId={parentId}
         type="edit"
+        selectedCatalogueCategory={selectedCatalogueCategory}
+        resetSelectedCatalogueCategory={() =>
+          setSelectedCatalogueCategory(undefined)
+        }
+      />
+      <CatalogueCategoryDialog
+        open={saveAsCategoryDialogOpen}
+        onClose={() => setSaveAsCategoryDialogOpen(false)}
+        parentId={parentId}
+        type="save as"
         selectedCatalogueCategory={selectedCatalogueCategory}
         resetSelectedCatalogueCategory={() =>
           setSelectedCatalogueCategory(undefined)

--- a/src/catalogue/category/catalogueCard.component.test.tsx
+++ b/src/catalogue/category/catalogueCard.component.test.tsx
@@ -64,7 +64,6 @@ describe('Catalogue Card', () => {
         name: 'actions Beam Characterization catalogue category button',
       })
     );
-
     expect(editButton).not.toBeVisible();
   });
 

--- a/src/catalogue/category/catalogueCard.component.test.tsx
+++ b/src/catalogue/category/catalogueCard.component.test.tsx
@@ -35,9 +35,33 @@ describe('Catalogue Card', () => {
     expect(screen.getByText('Beam Characterization')).toBeInTheDocument();
   });
 
+  it('opens the actions menu', async () => {
+    createView();
+    const actionsButton = screen.getByRole('button', {
+      name: 'actions Beam Characterization catalogue category button',
+    });
+    await user.click(actionsButton);
+
+    const editButton = screen.getByRole('menuitem', {
+      name: 'edit Beam Characterization catalogue category button',
+    });
+
+    const deleteButton = screen.getByRole('menuitem', {
+      name: 'delete Beam Characterization catalogue category button',
+    });
+
+    expect(editButton).toBeVisible();
+    expect(deleteButton).toBeVisible();
+  });
+
   it('opens the delete dialog', async () => {
     createView();
-    const deleteButton = screen.getByRole('button', {
+    const actionsButton = screen.getByRole('button', {
+      name: 'actions Beam Characterization catalogue category button',
+    });
+    await user.click(actionsButton);
+
+    const deleteButton = screen.getByRole('menuitem', {
       name: 'delete Beam Characterization catalogue category button',
     });
     await user.click(deleteButton);
@@ -56,7 +80,12 @@ describe('Catalogue Card', () => {
 
   it('opens the edit dialog', async () => {
     createView();
-    const editButton = screen.getByRole('button', {
+    const actionsButton = screen.getByRole('button', {
+      name: 'actions Beam Characterization catalogue category button',
+    });
+    await user.click(actionsButton);
+
+    const editButton = screen.getByRole('menuitem', {
       name: 'edit Beam Characterization catalogue category button',
     });
     await user.click(editButton);

--- a/src/catalogue/category/catalogueCard.component.test.tsx
+++ b/src/catalogue/category/catalogueCard.component.test.tsx
@@ -35,7 +35,7 @@ describe('Catalogue Card', () => {
     expect(screen.getByText('Beam Characterization')).toBeInTheDocument();
   });
 
-  it('opens the actions menu', async () => {
+  it.only('opens the actions menu and closes it', async () => {
     createView();
     const actionsButton = screen.getByRole('button', {
       name: 'actions Beam Characterization catalogue category button',
@@ -46,12 +46,26 @@ describe('Catalogue Card', () => {
       name: 'edit Beam Characterization catalogue category button',
     });
 
+    const saveAsButton = screen.getByRole('menuitem', {
+      name: 'save as Beam Characterization catalogue category button',
+    });
+
     const deleteButton = screen.getByRole('menuitem', {
       name: 'delete Beam Characterization catalogue category button',
     });
 
     expect(editButton).toBeVisible();
     expect(deleteButton).toBeVisible();
+    expect(saveAsButton).toBeVisible();
+
+    await user.click(editButton);
+    await user.click(
+      screen.getByRole('button', {
+        name: 'actions Beam Characterization catalogue category button',
+      })
+    );
+
+    expect(editButton).not.toBeVisible();
   });
 
   it('opens the delete dialog', async () => {

--- a/src/catalogue/category/catalogueCard.component.test.tsx
+++ b/src/catalogue/category/catalogueCard.component.test.tsx
@@ -35,7 +35,7 @@ describe('Catalogue Card', () => {
     expect(screen.getByText('Beam Characterization')).toBeInTheDocument();
   });
 
-  it.only('opens the actions menu and closes it', async () => {
+  it('opens the actions menu and closes it', async () => {
     createView();
     const actionsButton = screen.getByRole('button', {
       name: 'actions Beam Characterization catalogue category button',

--- a/src/catalogue/category/catalogueCard.component.tsx
+++ b/src/catalogue/category/catalogueCard.component.tsx
@@ -14,11 +14,13 @@ import {
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import SaveAsIcon from '@mui/icons-material/SaveAs';
 import { CatalogueCategory } from '../../app.types';
 import { Link } from 'react-router-dom';
 export interface CatalogueCardProps extends CatalogueCategory {
   onChangeOpenDeleteDialog: (catalogueCategory: CatalogueCategory) => void;
   onChangeOpenEditDialog: (catalogueCategory: CatalogueCategory) => void;
+  onChangeOpenSaveAsDialog: (catalogueCategory: CatalogueCategory) => void;
   onToggleSelect: (catalogueCategory: CatalogueCategory) => void;
   isSelected: boolean;
 }
@@ -27,6 +29,7 @@ function CatalogueCard(props: CatalogueCardProps) {
   const {
     onChangeOpenDeleteDialog,
     onChangeOpenEditDialog,
+    onChangeOpenSaveAsDialog,
     onToggleSelect,
     isSelected,
     ...catalogueCategory
@@ -120,6 +123,21 @@ function CatalogueCard(props: CatalogueCardProps) {
             </MenuItem>
             <MenuItem
               key={1}
+              aria-label={`Save as ${catalogueCategory.name} catalogue category button`}
+              onClick={(event) => {
+                event.preventDefault();
+                onChangeOpenSaveAsDialog(catalogueCategory);
+                setMenuOpen(false);
+              }}
+              sx={{ m: 0 }}
+            >
+              <ListItemIcon>
+                <SaveAsIcon />
+              </ListItemIcon>
+              Save as
+            </MenuItem>
+            <MenuItem
+              key={2}
               onClick={(event) => {
                 event.preventDefault();
                 onChangeOpenDeleteDialog(catalogueCategory);

--- a/src/catalogue/category/catalogueCard.component.tsx
+++ b/src/catalogue/category/catalogueCard.component.tsx
@@ -7,12 +7,15 @@ import {
   CardActions,
   IconButton,
   Checkbox,
+  MenuItem,
+  ListItemIcon,
+  Menu,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import { CatalogueCategory } from '../../app.types';
 import { Link } from 'react-router-dom';
-
 export interface CatalogueCardProps extends CatalogueCategory {
   onChangeOpenDeleteDialog: (catalogueCategory: CatalogueCategory) => void;
   onChangeOpenEditDialog: (catalogueCategory: CatalogueCategory) => void;
@@ -33,10 +36,13 @@ function CatalogueCard(props: CatalogueCardProps) {
     onToggleSelect(catalogueCategory);
   };
 
+  const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
   return (
     <Button
       component={Link}
-      to={`${catalogueCategory.id}`}
+      to={menuOpen ? '' : `${catalogueCategory.id}`}
       fullWidth
       sx={{
         display: 'flex',
@@ -83,21 +89,51 @@ function CatalogueCard(props: CatalogueCardProps) {
           <IconButton
             onClick={(event) => {
               event.preventDefault();
-              onChangeOpenEditDialog(catalogueCategory);
+              setAnchorEl(event.currentTarget);
+              setMenuOpen(true);
             }}
-            aria-label={`edit ${catalogueCategory.name} catalogue category button`}
+            aria-label={`actions ${catalogueCategory.name} catalogue category button`}
           >
-            <EditIcon />
+            <MoreHorizIcon />
           </IconButton>
-          <IconButton
-            onClick={(event) => {
-              event.preventDefault();
-              onChangeOpenDeleteDialog(catalogueCategory);
+          <Menu
+            anchorEl={anchorEl}
+            open={menuOpen}
+            onClose={(event) => {
+              setMenuOpen(false);
             }}
-            aria-label={`delete ${catalogueCategory.name} catalogue category button`}
           >
-            <DeleteIcon />
-          </IconButton>
+            <MenuItem
+              key={0}
+              onClick={(event) => {
+                event.preventDefault();
+                onChangeOpenEditDialog(catalogueCategory);
+                setMenuOpen(false);
+              }}
+              aria-label={`edit ${catalogueCategory.name} catalogue category button`}
+              sx={{ m: 0 }}
+            >
+              <ListItemIcon>
+                <EditIcon />
+              </ListItemIcon>
+              Edit
+            </MenuItem>
+            <MenuItem
+              key={1}
+              onClick={(event) => {
+                event.preventDefault();
+                onChangeOpenDeleteDialog(catalogueCategory);
+                setMenuOpen(false);
+              }}
+              aria-label={`delete ${catalogueCategory.name} catalogue category button`}
+              sx={{ m: 0 }}
+            >
+              <ListItemIcon>
+                <DeleteIcon />
+              </ListItemIcon>
+              Delete
+            </MenuItem>
+          </Menu>
         </CardActions>
       </Card>
     </Button>

--- a/src/catalogue/category/catalogueCard.component.tsx
+++ b/src/catalogue/category/catalogueCard.component.tsx
@@ -39,6 +39,10 @@ function CatalogueCard(props: CatalogueCardProps) {
     onToggleSelect(catalogueCategory);
   };
 
+  const handleActionsClose = () => {
+    setMenuOpen(false);
+  };
+
   const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
@@ -102,9 +106,7 @@ function CatalogueCard(props: CatalogueCardProps) {
           <Menu
             anchorEl={anchorEl}
             open={menuOpen}
-            onClose={(event) => {
-              setMenuOpen(false);
-            }}
+            onClose={handleActionsClose}
           >
             <MenuItem
               key={0}

--- a/src/catalogue/category/catalogueCard.component.tsx
+++ b/src/catalogue/category/catalogueCard.component.tsx
@@ -49,7 +49,7 @@ function CatalogueCard(props: CatalogueCardProps) {
   return (
     <Button
       component={Link}
-      to={menuOpen ? '' : `${catalogueCategory.id}`}
+      to={catalogueCategory.id}
       fullWidth
       sx={{
         display: 'flex',
@@ -106,6 +106,9 @@ function CatalogueCard(props: CatalogueCardProps) {
           <Menu
             anchorEl={anchorEl}
             open={menuOpen}
+            onClick={(event) => {
+              event.preventDefault();
+            }}
             onClose={handleActionsClose}
           >
             <MenuItem
@@ -113,7 +116,7 @@ function CatalogueCard(props: CatalogueCardProps) {
               onClick={(event) => {
                 event.preventDefault();
                 onChangeOpenEditDialog(catalogueCategory);
-                setMenuOpen(false);
+                handleActionsClose();
               }}
               aria-label={`edit ${catalogueCategory.name} catalogue category button`}
               sx={{ m: 0 }}
@@ -129,7 +132,7 @@ function CatalogueCard(props: CatalogueCardProps) {
               onClick={(event) => {
                 event.preventDefault();
                 onChangeOpenSaveAsDialog(catalogueCategory);
-                setMenuOpen(false);
+                handleActionsClose();
               }}
               sx={{ m: 0 }}
             >
@@ -143,7 +146,7 @@ function CatalogueCard(props: CatalogueCardProps) {
               onClick={(event) => {
                 event.preventDefault();
                 onChangeOpenDeleteDialog(catalogueCategory);
-                setMenuOpen(false);
+                handleActionsClose();
               }}
               aria-label={`delete ${catalogueCategory.name} catalogue category button`}
               sx={{ m: 0 }}

--- a/src/catalogue/category/catalogueCard.component.tsx
+++ b/src/catalogue/category/catalogueCard.component.tsx
@@ -123,7 +123,7 @@ function CatalogueCard(props: CatalogueCardProps) {
             </MenuItem>
             <MenuItem
               key={1}
-              aria-label={`Save as ${catalogueCategory.name} catalogue category button`}
+              aria-label={`save as ${catalogueCategory.name} catalogue category button`}
               onClick={(event) => {
                 event.preventDefault();
                 onChangeOpenSaveAsDialog(catalogueCategory);

--- a/src/catalogue/category/catalogueCategoryDialog.component.test.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.test.tsx
@@ -611,4 +611,54 @@ describe('Catalogue Category Dialog', () => {
       expect(onClose).not.toHaveBeenCalled();
     });
   });
+
+  describe('Save as Catalogue Category Dialog', () => {
+    //All of actual logic is same as add so is tested above
+    //checks that the dialog renders/opens correctly for `save as`
+
+    let axiosPostSpy;
+    let mockData: CatalogueCategory = {
+      name: 'test',
+      parent_id: null,
+      id: '1',
+      code: 'test',
+      is_leaf: false,
+    };
+
+    beforeEach(() => {
+      props = {
+        open: true,
+        onClose: onClose,
+        parentId: null,
+        type: 'save as',
+        selectedCatalogueCategory: mockData,
+        resetSelectedCatalogueCategory: resetSelectedCatalogueCategory,
+      };
+      user = userEvent.setup();
+      axiosPostSpy = jest.spyOn(axios, 'post');
+    });
+
+    it('renders correctly when saving as', async () => {
+      createView();
+
+      expect(screen.getByText('Add Catalogue Category')).toBeInTheDocument();
+    });
+
+    it('saves as a catalogue category', async () => {
+      createView();
+
+      const values = {
+        name: 'Catalogue Category name',
+      };
+      await modifyValues(values);
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-categories', {
+        ...values,
+        is_leaf: false,
+      });
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/catalogue/category/catalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.tsx
@@ -36,7 +36,7 @@ export interface CatalogueCategoryDialogProps {
   open: boolean;
   onClose: () => void;
   parentId: string | null;
-  type: 'add' | 'edit';
+  type: 'add' | 'edit' | 'save as';
   selectedCatalogueCategory?: CatalogueCategory;
   resetSelectedCatalogueCategory: () => void;
 }
@@ -438,9 +438,9 @@ const CatalogueCategoryDialog = React.memo(
               variant="outlined"
               sx={{ width: '50%', mx: 1 }}
               onClick={
-                type === 'add'
-                  ? handleAddCatalogueCategory
-                  : handleEditCatalogueCategory
+                type === 'edit'
+                  ? handleEditCatalogueCategory
+                  : handleAddCatalogueCategory
               }
               disabled={
                 formError !== undefined ||


### PR DESCRIPTION
## Description

Changed card view to have more actions button which then displays edit, save as and delete options like in catalogue items table view.

Implemented `save as` logic for catalogue categories

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

closes #172