### PR TITLE
Fix manufacturer edit url only #279

### DIFF
--- a/cypress/e2e/catalogue/catalogueCategory.cy.ts
+++ b/cypress/e2e/catalogue/catalogueCategory.cy.ts
@@ -53,6 +53,7 @@ describe('Catalogue Category', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     // Doesn't seem to wait for save to click on CI, so allowing an extra pause here
     cy.findByRole('dialog').should('not.exist');
@@ -102,6 +103,7 @@ describe('Catalogue Category', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'POST',
@@ -188,6 +190,7 @@ describe('Catalogue Category', () => {
     cy.findByText('Number').click();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'POST',
@@ -246,6 +249,7 @@ describe('Catalogue Category', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'PATCH',
@@ -317,6 +321,7 @@ describe('Catalogue Category', () => {
     cy.findAllByLabelText('Property Name *').first().type('Updated Field');
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'PATCH',
@@ -371,6 +376,7 @@ describe('Catalogue Category', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'PATCH',

--- a/cypress/e2e/catalogue/catalogueItems.cy.ts
+++ b/cypress/e2e/catalogue/catalogueItems.cy.ts
@@ -30,6 +30,7 @@ describe('Catalogue Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'POST',
@@ -52,6 +53,7 @@ describe('Catalogue Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'POST',
@@ -82,6 +84,7 @@ describe('Catalogue Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'POST',
@@ -382,6 +385,7 @@ describe('Catalogue Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'PATCH',
@@ -405,6 +409,7 @@ describe('Catalogue Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'PATCH',

--- a/cypress/e2e/items.cy.ts
+++ b/cypress/e2e/items.cy.ts
@@ -68,6 +68,7 @@ describe('Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'POST',
@@ -124,6 +125,7 @@ describe('Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'POST',
@@ -272,6 +274,7 @@ describe('Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'POST',
@@ -336,6 +339,7 @@ describe('Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'PATCH',
@@ -373,6 +377,7 @@ describe('Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'PATCH',
@@ -401,6 +406,7 @@ describe('Items', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'PATCH',

--- a/cypress/e2e/manufacturer/manufacturer.cy.ts
+++ b/cypress/e2e/manufacturer/manufacturer.cy.ts
@@ -62,6 +62,7 @@ describe('Manufacturer', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'POST',
@@ -85,6 +86,7 @@ describe('Manufacturer', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'POST',
@@ -209,6 +211,7 @@ describe('Manufacturer', () => {
     cy.startSnoopingBrowserMockedRequest();
 
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'PATCH',

--- a/cypress/e2e/systems.cy.ts
+++ b/cypress/e2e/systems.cy.ts
@@ -89,10 +89,12 @@ describe('Systems', () => {
   describe('Add', () => {
     it('adds a root system with only required parameters', () => {
       cy.findByRole('button', { name: 'add system' }).click();
-
       cy.findByLabelText('Name *').type('System name');
+
       cy.startSnoopingBrowserMockedRequest();
+
       cy.findByRole('button', { name: 'Save' }).click();
+      cy.findByRole('dialog').should('not.exist');
 
       cy.findBrowserMockedRequests({
         method: 'POST',
@@ -120,7 +122,9 @@ describe('Systems', () => {
       cy.findByRole('option', { name: 'high' }).click();
 
       cy.startSnoopingBrowserMockedRequest();
+
       cy.findByRole('button', { name: 'Save' }).click();
+      cy.findByRole('dialog').should('not.exist');
 
       cy.findBrowserMockedRequests({
         method: 'POST',
@@ -144,10 +148,12 @@ describe('Systems', () => {
       cy.visit('/systems/65328f34a40ff5301575a4e3');
 
       cy.findByRole('button', { name: 'add subsystem' }).click();
-
       cy.findByLabelText('Name *').type('System name');
+
       cy.startSnoopingBrowserMockedRequest();
+
       cy.findByRole('button', { name: 'Save' }).click();
+      cy.findByRole('dialog').should('not.exist');
 
       cy.findBrowserMockedRequests({
         method: 'POST',
@@ -222,7 +228,9 @@ describe('Systems', () => {
       cy.findByRole('option', { name: 'medium' }).click();
 
       cy.startSnoopingBrowserMockedRequest();
+
       cy.findByRole('button', { name: 'Save' }).click();
+      cy.findByRole('dialog').should('not.exist');
 
       cy.findBrowserMockedRequests({
         method: 'PATCH',
@@ -250,7 +258,9 @@ describe('Systems', () => {
       cy.findByLabelText('Name *').clear().type('System name');
 
       cy.startSnoopingBrowserMockedRequest();
+
       cy.findByRole('button', { name: 'Save' }).click();
+      cy.findByRole('dialog').should('not.exist');
 
       cy.findBrowserMockedRequests({
         method: 'PATCH',
@@ -361,7 +371,9 @@ describe('Systems', () => {
       cy.findByRole('option', { name: 'medium' }).click();
 
       cy.startSnoopingBrowserMockedRequest();
+
       cy.findByRole('button', { name: 'Save' }).click();
+      cy.findByRole('dialog').should('not.exist');
 
       cy.findBrowserMockedRequests({
         method: 'POST',
@@ -393,7 +405,9 @@ describe('Systems', () => {
       cy.findByLabelText('Name *').clear().type('System name');
 
       cy.startSnoopingBrowserMockedRequest();
+
       cy.findByRole('button', { name: 'Save' }).click();
+      cy.findByRole('dialog').should('not.exist');
 
       cy.findBrowserMockedRequests({
         method: 'POST',
@@ -423,7 +437,9 @@ describe('Systems', () => {
     cy.findByLabelText('Name *').clear().type('System name');
 
     cy.startSnoopingBrowserMockedRequest();
+
     cy.findByRole('button', { name: 'Save' }).click();
+    cy.findByRole('dialog').should('not.exist');
 
     cy.findBrowserMockedRequests({
       method: 'PATCH',

--- a/src/manufacturer/manufacturerDialog.component.tsx
+++ b/src/manufacturer/manufacturerDialog.component.tsx
@@ -245,7 +245,7 @@ function ManufacturerDialog(props: ManufacturerDialogProps) {
         manufacturerDetails.telephone !== selectedManufacturerData.telephone;
 
       let ManufacturerToEdit: EditManufacturer = {
-        id: selectedManufacturerData?.id,
+        id: selectedManufacturerData.id,
       };
 
       isNameUpdated && (ManufacturerToEdit.name = manufacturerDetails.name);
@@ -301,7 +301,8 @@ function ManufacturerDialog(props: ManufacturerDialogProps) {
         (ManufacturerToEdit.telephone = manufacturerDetails.telephone);
 
       if (
-        (selectedManufacturerData.id && isNameUpdated) ||
+        isNameUpdated ||
+        isURLUpdated ||
         isAddressLineUpdated ||
         isTownUpdated ||
         isCountyUpdated ||

--- a/src/systems/systems.component.test.tsx
+++ b/src/systems/systems.component.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 
 describe('Systems', () => {
   // Quite a few of these take more than 5 seconds on CI
-  jest.setTimeout(12000);
+  jest.setTimeout(14000);
 
   let user;
   const createView = (path: string) => {


### PR DESCRIPTION
## Description

Allows url on its own to be updated in the manufacturer dialog. Also hopefully fixes some flakiness in the e2e tests caused by cypress not waiting for the save button click to finish before asserting the mocked requests so I just added the same fix I applied in #284 everywhere.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #279 
