### PR TITLE
Remove trailing slashes on API urls

### DIFF
--- a/cypress/e2e/catalogue/catalogueCategory.cy.ts
+++ b/cypress/e2e/catalogue/catalogueCategory.cy.ts
@@ -43,7 +43,7 @@ describe('Catalogue Category', () => {
 
   it('should be able to change page', () => {
     cy.editEndpointResponse({
-      url: '/v1/catalogue-categories/',
+      url: '/v1/catalogue-categories',
       data: createMockData(),
       statusCode: 200,
     });
@@ -56,7 +56,7 @@ describe('Catalogue Category', () => {
 
   it('should be able to change max results', () => {
     cy.editEndpointResponse({
-      url: '/v1/catalogue-categories/',
+      url: '/v1/catalogue-categories',
       data: createMockData(),
       statusCode: 200,
     });
@@ -746,7 +746,7 @@ describe('Catalogue Category', () => {
 
   it('when root has no data it displays no catagories error message', () => {
     cy.editEndpointResponse({
-      url: '/v1/catalogue-categories/',
+      url: '/v1/catalogue-categories',
       data: [],
       statusCode: 200,
     });

--- a/cypress/e2e/items.cy.ts
+++ b/cypress/e2e/items.cy.ts
@@ -76,7 +76,7 @@ describe('Items', () => {
 
     cy.findBrowserMockedRequests({
       method: 'POST',
-      url: '/v1/items/',
+      url: '/v1/items',
     }).should(async (postRequests) => {
       expect(postRequests.length).eq(1);
       expect(JSON.stringify(await postRequests[0].json())).equal(
@@ -124,7 +124,7 @@ describe('Items', () => {
 
     cy.findBrowserMockedRequests({
       method: 'POST',
-      url: '/v1/items/',
+      url: '/v1/items',
     }).should(async (postRequests) => {
       expect(postRequests.length).eq(1);
       expect(JSON.stringify(await postRequests[0].json())).equal(
@@ -185,7 +185,7 @@ describe('Items', () => {
 
     cy.findBrowserMockedRequests({
       method: 'POST',
-      url: '/v1/items/',
+      url: '/v1/items',
     }).should(async (postRequests) => {
       expect(postRequests.length).eq(1);
       expect(JSON.stringify(await postRequests[0].json())).equal(
@@ -342,7 +342,7 @@ describe('Items', () => {
 
     cy.findBrowserMockedRequests({
       method: 'POST',
-      url: '/v1/items/',
+      url: '/v1/items',
     }).should(async (postRequests) => {
       expect(postRequests.length).eq(1);
       expect(JSON.stringify(await postRequests[0].json())).equal(

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -114,7 +114,7 @@ declare global {
        * Edits the response of the endpoint request 
        * 
        * @example  cy.editEndpointResponse({
-                    url: '/v1/catalogue-categories/',
+                    url: '/v1/catalogue-categories',
                     data: [],
                     statusCode: 200,
                    });

--- a/src/api/catalogueCategory.tsx
+++ b/src/api/catalogueCategory.tsx
@@ -33,7 +33,7 @@ const fetchCatalogueCategories = async (
   queryParams.append('parent_id', parent_id);
 
   return axios
-    .get(`${apiUrl}/v1/catalogue-categories/`, {
+    .get(`${apiUrl}/v1/catalogue-categories`, {
       params: queryParams,
     })
     .then((response) => {

--- a/src/api/catalogueCategory.tsx
+++ b/src/api/catalogueCategory.tsx
@@ -71,14 +71,14 @@ const fetchCatalogueBreadcrumbs = async (
 };
 
 export const useCatalogueBreadcrumbs = (
-  id: string | null
+  id?: string | null
 ): UseQueryResult<BreadcrumbsInfo, AxiosError> => {
   return useQuery({
     queryKey: ['CatalogueBreadcrumbs', id],
     queryFn: (params) => {
       return fetchCatalogueBreadcrumbs(id ?? '');
     },
-    enabled: id !== null,
+    enabled: !!id,
   });
 };
 
@@ -362,13 +362,13 @@ const fetchCatalogueCategory = async (
 };
 
 export const useCatalogueCategory = (
-  id: string | null
+  id?: string | null
 ): UseQueryResult<CatalogueCategory, AxiosError> => {
   return useQuery({
     queryKey: ['CatalogueCategory', id],
     queryFn: (params) => {
       return fetchCatalogueCategory(id ?? '');
     },
-    enabled: id !== null,
+    enabled: !!id,
   });
 };

--- a/src/api/catalogueCategory.tsx
+++ b/src/api/catalogueCategory.tsx
@@ -71,14 +71,14 @@ const fetchCatalogueBreadcrumbs = async (
 };
 
 export const useCatalogueBreadcrumbs = (
-  id: string
+  id: string | null
 ): UseQueryResult<BreadcrumbsInfo, AxiosError> => {
   return useQuery({
     queryKey: ['CatalogueBreadcrumbs', id],
     queryFn: (params) => {
-      return fetchCatalogueBreadcrumbs(id);
+      return fetchCatalogueBreadcrumbs(id ?? '');
     },
-    enabled: id !== '',
+    enabled: id !== null,
   });
 };
 
@@ -362,13 +362,13 @@ const fetchCatalogueCategory = async (
 };
 
 export const useCatalogueCategory = (
-  id: string | undefined
+  id: string | null
 ): UseQueryResult<CatalogueCategory, AxiosError> => {
   return useQuery({
     queryKey: ['CatalogueCategory', id],
     queryFn: (params) => {
-      return fetchCatalogueCategory(id);
+      return fetchCatalogueCategory(id ?? '');
     },
-    enabled: id !== undefined,
+    enabled: id !== null,
   });
 };

--- a/src/api/catalogueItem.tsx
+++ b/src/api/catalogueItem.tsx
@@ -27,7 +27,7 @@ const addCatalogueItem = async (
     apiUrl = settingsResult['apiUrl'];
   }
   return axios
-    .post<CatalogueItem>(`${apiUrl}/v1/catalogue-items/`, catalogueItem)
+    .post<CatalogueItem>(`${apiUrl}/v1/catalogue-items`, catalogueItem)
     .then((response) => response.data);
 };
 
@@ -64,7 +64,7 @@ const fetchCatalogueItems = async (
     queryParams.append('catalogue_category_id', catalogueCategoryId);
 
   return axios
-    .get(`${apiUrl}/v1/catalogue-items/`, {
+    .get(`${apiUrl}/v1/catalogue-items`, {
       params: queryParams,
     })
     .then((response) => {

--- a/src/api/item.tsx
+++ b/src/api/item.tsx
@@ -76,7 +76,7 @@ export const useItems = (
   });
 };
 
-const fetchItem = async (id?: string): Promise<Item> => {
+const fetchItem = async (id: string): Promise<Item> => {
   let apiUrl: string;
   apiUrl = '';
   const settingsResult = await settings;
@@ -94,11 +94,13 @@ const fetchItem = async (id?: string): Promise<Item> => {
     });
 };
 
-export const useItem = (id?: string): UseQueryResult<Item, AxiosError> => {
+export const useItem = (
+  id?: string | null
+): UseQueryResult<Item, AxiosError> => {
   return useQuery({
     queryKey: ['Item', id],
     queryFn: (params) => {
-      return fetchItem(id);
+      return fetchItem(id ?? '');
     },
     enabled: !!id,
   });

--- a/src/api/item.tsx
+++ b/src/api/item.tsx
@@ -24,7 +24,7 @@ const addItem = async (item: AddItem): Promise<Item> => {
     apiUrl = settingsResult['apiUrl'];
   }
   return axios
-    .post<Item>(`${apiUrl}/v1/items/`, item)
+    .post<Item>(`${apiUrl}/v1/items`, item)
     .then((response) => response.data);
 };
 
@@ -55,7 +55,7 @@ const fetchItems = async (
     queryParams.append('catalogue_item_id', catalogue_item_id);
 
   return axios
-    .get(`${apiUrl}/v1/items/`, {
+    .get(`${apiUrl}/v1/items`, {
       params: queryParams,
     })
     .then((response) => {

--- a/src/api/manufacturer.tsx
+++ b/src/api/manufacturer.tsx
@@ -97,9 +97,7 @@ export const useDeleteManufacturer = (): UseMutationResult<
   });
 };
 
-const fetchManufacturer = async (
-  id: string | undefined
-): Promise<Manufacturer> => {
+const fetchManufacturer = async (id: string): Promise<Manufacturer> => {
   let apiUrl: string;
   apiUrl = '';
   const settingsResult = await settings;
@@ -112,15 +110,15 @@ const fetchManufacturer = async (
 };
 
 export const useManufacturer = (
-  id: string | undefined
+  id?: string | null
 ): UseQueryResult<Manufacturer, AxiosError> => {
   return useQuery({
     queryKey: ['Manufacturer', id],
 
     queryFn: (params) => {
-      return fetchManufacturer(id);
+      return fetchManufacturer(id ?? '');
     },
-    enabled: id !== undefined,
+    enabled: !!id,
   });
 };
 

--- a/src/api/systems.tsx
+++ b/src/api/systems.tsx
@@ -76,16 +76,16 @@ const fetchSystem = async (id: string): Promise<System> => {
   });
 };
 
-// Allows a value of null to disable
+// Allows a value of undefined or null to disable
 export const useSystem = (
-  id: string | null
+  id?: string | null
 ): UseQueryResult<System, AxiosError> => {
   return useQuery({
     queryKey: ['System', id],
     queryFn: () => {
       return fetchSystem(id ?? '');
     },
-    enabled: id !== null,
+    enabled: !!id,
   });
 };
 
@@ -107,14 +107,14 @@ const fetchSystemsBreadcrumbs = async (
 };
 
 export const useSystemsBreadcrumbs = (
-  id: string | null
+  id?: string | null
 ): UseQueryResult<BreadcrumbsInfo, AxiosError> => {
   return useQuery({
     queryKey: ['SystemBreadcrumbs', id],
     queryFn: () => {
       return fetchSystemsBreadcrumbs(id ?? '');
     },
-    enabled: id !== null,
+    enabled: !!id,
   });
 };
 

--- a/src/catalogue/catalogue.component.test.tsx
+++ b/src/catalogue/catalogue.component.test.tsx
@@ -213,7 +213,7 @@ describe('Catalogue', () => {
 
   it('root has no categories so there is no results page', async () => {
     server.use(
-      rest.get('/v1/catalogue-categories/', (req, res, ctx) => {
+      rest.get('/v1/catalogue-categories', (req, res, ctx) => {
         return res(ctx.status(200), ctx.json([]));
       })
     );

--- a/src/catalogue/catalogue.component.tsx
+++ b/src/catalogue/catalogue.component.tsx
@@ -31,14 +31,14 @@ import CatalogueItemsTable from './items/catalogueItemsTable.component';
 import { generateUniqueName } from '../utils';
 import CatalogueCardView from './category/catalogueCardView.component';
 
-/* Returns function that navigates to a specific catalogue category id (or to the root of all categories
-   if given null) */
-export const useNavigateToCatalogueCategory = () => {
+/* Returns function that navigates to a specific catalogue category id or catalogue path (or to the root of
+   all categories if given null) */
+export const useNavigateToCatalogue = () => {
   const navigate = useNavigate();
 
   return React.useCallback(
-    (newId: string | null) => {
-      navigate(`/catalogue${newId ? `/${newId}` : ''}`);
+    (newIdPath: string | null) => {
+      navigate(`/catalogue${newIdPath ? `/${newIdPath}` : ''}`);
     },
     [navigate]
   );
@@ -126,7 +126,7 @@ export function matchCatalogueItemProperties(
 function Catalogue() {
   // Navigation
   const catalogueCategoryId = useCatalogueCategoryId();
-  const navigateToCatalogueCategory = useNavigateToCatalogueCategory();
+  const navigateToCatalogue = useNavigateToCatalogue();
 
   const {
     data: catalogueCategoryDetail,
@@ -238,9 +238,9 @@ function Catalogue() {
         >
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <Breadcrumbs
-              onChangeNode={navigateToCatalogueCategory}
+              onChangeNode={navigateToCatalogue}
               breadcrumbsInfo={catalogueBreadcrumbs}
-              onChangeNavigateHome={() => navigateToCatalogueCategory(null)}
+              onChangeNavigateHome={() => navigateToCatalogue(null)}
               navigateHomeAriaLabel={'navigate to catalogue home'}
             />
             <NavigateNext

--- a/src/catalogue/catalogue.component.tsx
+++ b/src/catalogue/catalogue.component.tsx
@@ -31,6 +31,35 @@ import CatalogueItemsTable from './items/catalogueItemsTable.component';
 import { generateUniqueName } from '../utils';
 import CatalogueCardView from './category/catalogueCardView.component';
 
+/* Returns function that navigates to a specific catalogue category id (or to the root of all categories
+   if given null) */
+export const useNavigateToCatalogueCategory = () => {
+  const navigate = useNavigate();
+
+  return React.useCallback(
+    (newId: string | null) => {
+      navigate(`/catalogue${newId ? `/${newId}` : ''}`);
+    },
+    [navigate]
+  );
+};
+
+/* Returns the catalogue category id from the location pathname (null when not found) */
+export const useCatalogueCategoryId = (): string | null => {
+  // Navigation setup
+  const location = useLocation();
+
+  return React.useMemo(() => {
+    let catalogueCategoryId: string | null = location.pathname.replace(
+      '/catalogue',
+      ''
+    );
+    catalogueCategoryId =
+      catalogueCategoryId === '' ? null : catalogueCategoryId.replace('/', '');
+    return catalogueCategoryId;
+  }, [location.pathname]);
+};
+
 export interface AddCatalogueButtonProps {
   disabled: boolean;
   parentId: string | null;
@@ -93,26 +122,19 @@ export function matchCatalogueItemProperties(
 
   return result;
 }
-function Catalogue() {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const onChangeNode = React.useCallback(
-    (newId: string) => {
-      navigate(`/catalogue/${newId}`);
-    },
-    [navigate]
-  );
 
-  const catalogueId = location.pathname.replace('/catalogue', '');
+function Catalogue() {
+  // Navigation
+  const catalogueCategoryId = useCatalogueCategoryId();
+  const navigateToCatalogueCategory = useNavigateToCatalogueCategory();
 
   const {
     data: catalogueCategoryDetail,
     isLoading: catalogueCategoryDetailLoading,
-  } = useCatalogueCategory(catalogueId.replace('/', ''));
+  } = useCatalogueCategory(catalogueCategoryId);
 
-  const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
-    catalogueId.replace('/', '')
-  );
+  const { data: catalogueBreadcrumbs } =
+    useCatalogueBreadcrumbs(catalogueCategoryId);
 
   const parentInfo = React.useMemo(
     () => catalogueCategoryDetail,
@@ -126,7 +148,8 @@ function Catalogue() {
     isLoading: catalogueCategoryDataLoading,
   } = useCatalogueCategories(
     catalogueCategoryDetailLoading ? true : !!parentInfo && parentInfo.is_leaf,
-    !catalogueId ? 'null' : catalogueId.replace('/', '')
+    // String value of null for filtering root catalogue category
+    catalogueCategoryId === null ? 'null' : catalogueCategoryId
   );
 
   const catalogueCategoryNames: string[] =
@@ -215,11 +238,9 @@ function Catalogue() {
         >
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <Breadcrumbs
-              onChangeNode={onChangeNode}
+              onChangeNode={navigateToCatalogueCategory}
               breadcrumbsInfo={catalogueBreadcrumbs}
-              onChangeNavigateHome={() => {
-                navigate('/catalogue');
-              }}
+              onChangeNavigateHome={() => navigateToCatalogueCategory(null)}
               navigateHomeAriaLabel={'navigate to catalogue home'}
             />
             <NavigateNext
@@ -227,7 +248,9 @@ function Catalogue() {
               sx={{ color: 'text.secondary', margin: 1 }}
             />
             <AddCategoryButton
-              disabled={isLeafNode || (!parentInfo && catalogueId !== '')}
+              disabled={
+                isLeafNode || (!parentInfo && catalogueCategoryId !== null)
+              }
               parentId={parentId}
               type="add"
               resetSelectedCatalogueCategory={() =>
@@ -297,7 +320,7 @@ function Catalogue() {
               No results found
             </Typography>
             <Typography sx={{ textAlign: 'center' }}>
-              {!parentInfo && catalogueId !== ''
+              {!parentInfo && catalogueCategoryId !== null
                 ? 'The category you searched for does not exist. Please navigate home by pressing the home button at the top left of your screen.'
                 : 'There are no catalogue categories. Please add a category using the plus icon in the top left of your screen'}
             </Typography>

--- a/src/catalogue/category/catalogueCategoryDialog.component.test.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.test.tsx
@@ -624,11 +624,9 @@ describe('Catalogue Category Dialog', () => {
     });
 
     it('displays warning message when name already exists within the parent catalogue category', async () => {
-      props.selectedCatalogueCategory = {
-        ...mockData,
-        name: 'test_dup',
-      };
       createView();
+
+      await modifyValues({ name: 'test_dup' });
 
       const saveButton = screen.getByRole('button', { name: 'Save' });
       await user.click(saveButton);
@@ -814,10 +812,11 @@ describe('Catalogue Category Dialog', () => {
         selectedCatalogueCategory: {
           ...mockData,
           id: '4',
-          name: 'Error 500',
         },
       };
       createView();
+
+      await modifyValues({ name: 'Error 500' });
 
       const saveButton = screen.getByRole('button', { name: 'Save' });
       await user.click(saveButton);
@@ -883,17 +882,18 @@ describe('Catalogue Category Dialog', () => {
       props.selectedCatalogueCategory = {
         ...mockData,
         id: '4',
-        name: 'test',
       };
 
       createView();
+
+      await modifyValues({ name: 'test2' });
 
       const saveButton = screen.getByRole('button', { name: 'Save' });
       await user.click(saveButton);
 
       expect(axiosPatchSpy).toHaveBeenCalledWith('/v1/catalogue-categories/4', {
-        name: 'test',
-        is_leaf: false,
+        name: 'test2',
+        catalogue_item_properties: undefined,
       });
 
       expect(onClose).toHaveBeenCalled();
@@ -902,12 +902,12 @@ describe('Catalogue Category Dialog', () => {
     it('edits a new catalogue category at sub level ("/catalogue/*")', async () => {
       createView();
 
-      await modifyValues({ name: 'test' });
+      await modifyValues({ name: 'test2' });
 
       const saveButton = screen.getByRole('button', { name: 'Save' });
       await user.click(saveButton);
       expect(axiosPatchSpy).toHaveBeenCalledWith('/v1/catalogue-categories/1', {
-        name: 'test',
+        name: 'test2',
       });
 
       expect(onClose).toHaveBeenCalled();

--- a/src/catalogue/category/catalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.tsx
@@ -20,7 +20,6 @@ import { AxiosError } from 'axios';
 import React from 'react';
 import {
   useAddCatalogueCategory,
-  useCatalogueCategory,
   useEditCatalogueCategory,
 } from '../../api/catalogueCategory';
 import {
@@ -101,10 +100,6 @@ const CatalogueCategoryDialog = React.memo(
 
     const [catalogueItemPropertiesErrors, setCatalogueItemPropertiesErrors] =
       React.useState<CatalogueItemPropertiesErrorsType[]>([]);
-
-    const { data: selectedCatalogueCategoryData } = useCatalogueCategory(
-      selectedCatalogueCategory?.id
-    );
 
     const handleClose = React.useCallback(() => {
       onClose();
@@ -398,7 +393,7 @@ const CatalogueCategoryDialog = React.memo(
     const handleEditCatalogueCategory = React.useCallback(() => {
       let catalogueCategory: EditCatalogueCategory;
 
-      if (selectedCatalogueCategory && selectedCatalogueCategoryData) {
+      if (selectedCatalogueCategory) {
         const { hasErrors } = handleErrorStates();
         if (hasErrors) {
           return;
@@ -439,14 +434,14 @@ const CatalogueCategoryDialog = React.memo(
         };
 
         const isNameUpdated =
-          categoryData.name !== selectedCatalogueCategoryData?.name;
+          categoryData.name !== selectedCatalogueCategory?.name;
 
         const isIsLeafUpdated =
-          categoryData.is_leaf !== selectedCatalogueCategoryData?.is_leaf;
+          categoryData.is_leaf !== selectedCatalogueCategory?.is_leaf;
         const isCatalogueItemPropertiesUpdated =
           JSON.stringify(updatedProperties) !==
           JSON.stringify(
-            selectedCatalogueCategoryData?.catalogue_item_properties ?? null
+            selectedCatalogueCategory?.catalogue_item_properties ?? null
           );
 
         isNameUpdated && (catalogueCategory.name = categoryData.name);
@@ -490,7 +485,6 @@ const CatalogueCategoryDialog = React.memo(
       handleErrorStates,
       resetSelectedCatalogueCategory,
       selectedCatalogueCategory,
-      selectedCatalogueCategoryData,
     ]);
 
     return (

--- a/src/catalogue/category/catalogueCategoryDirectoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDirectoryDialog.component.tsx
@@ -63,7 +63,7 @@ const CatalogueCategoryDirectoryDialog = (
   const { mutateAsync: copyToCatalogueCategory } = useCopyToCatalogueCategory();
 
   const { data: targetCategory, isLoading: targetCategoryLoading } =
-    useCatalogueCategory(catalogueCurrDirId ?? undefined);
+    useCatalogueCategory(catalogueCurrDirId);
 
   const handleMoveToCatalogueCategory = React.useCallback(() => {
     // Either ensure finished loading, or moving to root
@@ -122,9 +122,8 @@ const CatalogueCategoryDirectoryDialog = (
     onChangeCatalogueCurrDirId(newId);
   };
 
-  const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
-    catalogueCurrDirId ?? ''
-  );
+  const { data: catalogueBreadcrumbs } =
+    useCatalogueBreadcrumbs(catalogueCurrDirId);
 
   return (
     <Dialog

--- a/src/catalogue/items/catalogueItemDirectoryDialog.component.test.tsx
+++ b/src/catalogue/items/catalogueItemDirectoryDialog.component.test.tsx
@@ -232,7 +232,7 @@ describe('catalogue item directory Dialog', () => {
 
       await user.click(moveButton);
       expect(onClose).toHaveBeenCalled();
-      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items/', {
+      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items', {
         catalogue_category_id: '8967',
         cost_gbp: 500,
         cost_to_rework_gbp: null,
@@ -253,7 +253,7 @@ describe('catalogue item directory Dialog', () => {
           { name: 'Accuracy', unit: '', value: '±0.5%' },
         ],
       });
-      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items/', {
+      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items', {
         catalogue_category_id: '8967',
         cost_gbp: 600,
         cost_to_rework_gbp: 89,
@@ -288,7 +288,7 @@ describe('catalogue item directory Dialog', () => {
 
       await user.click(moveButton);
       expect(onClose).toHaveBeenCalled();
-      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items/', {
+      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items', {
         catalogue_category_id: '5',
         cost_gbp: 500,
         cost_to_rework_gbp: null,
@@ -309,7 +309,7 @@ describe('catalogue item directory Dialog', () => {
           { name: 'Accuracy', unit: '', value: '±0.5%' },
         ],
       });
-      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items/', {
+      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items', {
         catalogue_category_id: '5',
         cost_gbp: 600,
         cost_to_rework_gbp: 89,

--- a/src/catalogue/items/catalogueItemDirectoryDialog.component.tsx
+++ b/src/catalogue/items/catalogueItemDirectoryDialog.component.tsx
@@ -73,9 +73,8 @@ const CatalogueItemDirectoryDialog = (
   const { mutateAsync: moveToCatalogueItem } = useMoveToCatalogueItem();
   const { mutateAsync: copyToCatalogueItem } = useCopyToCatalogueItem();
 
-  const { data: targetCatalogueCategory } = useCatalogueCategory(
-    catalogueCurrDirId ?? undefined
-  );
+  const { data: targetCatalogueCategory } =
+    useCatalogueCategory(catalogueCurrDirId);
 
   const [errorMessage, setErrorMessage] = React.useState<string>('');
 
@@ -135,9 +134,8 @@ const CatalogueItemDirectoryDialog = (
     onChangeCatalogueCurrDirId(newId);
   };
 
-  const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
-    catalogueCurrDirId ?? ''
-  );
+  const { data: catalogueBreadcrumbs } =
+    useCatalogueBreadcrumbs(catalogueCurrDirId);
 
   return (
     <Dialog

--- a/src/catalogue/items/catalogueItemsDialog.component.test.tsx
+++ b/src/catalogue/items/catalogueItemsDialog.component.test.tsx
@@ -209,7 +209,7 @@ describe('Catalogue Items Dialog', () => {
 
     await user.click(screen.getByRole('button', { name: 'Finish' }));
 
-    expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items/', {
+    expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items', {
       catalogue_category_id: '4',
       cost_gbp: 1200,
       cost_to_rework_gbp: 400,
@@ -274,7 +274,7 @@ describe('Catalogue Items Dialog', () => {
 
     await user.click(screen.getByRole('button', { name: 'Finish' }));
 
-    expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items/', {
+    expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items', {
       catalogue_category_id: '12',
       cost_gbp: 1200,
       cost_to_rework_gbp: 400,
@@ -411,7 +411,7 @@ describe('Catalogue Items Dialog', () => {
 
     await user.click(screen.getByRole('button', { name: 'Finish' }));
 
-    expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items/', {
+    expect(axiosPostSpy).toHaveBeenCalledWith('/v1/catalogue-items', {
       catalogue_category_id: '4',
       cost_gbp: 200,
       cost_to_rework_gbp: null,

--- a/src/catalogue/items/catalogueItemsLandingPage.component.tsx
+++ b/src/catalogue/items/catalogueItemsLandingPage.component.tsx
@@ -1,7 +1,7 @@
+import EditIcon from '@mui/icons-material/Edit';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import PrintIcon from '@mui/icons-material/Print';
-import EditIcon from '@mui/icons-material/Edit';
 import {
   Box,
   Button,
@@ -12,35 +12,30 @@ import {
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import React, { useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import {
   useCatalogueBreadcrumbs,
   useCatalogueCategory,
 } from '../../api/catalogueCategory';
 import { useCatalogueItem } from '../../api/catalogueItem';
 import { useManufacturer } from '../../api/manufacturer';
-import CatalogueItemsDialog from './catalogueItemsDialog.component';
-import Breadcrumbs from '../../view/breadcrumbs.component';
 import { BreadcrumbsInfo } from '../../app.types';
+import Breadcrumbs from '../../view/breadcrumbs.component';
+import { useNavigateToCatalogueCategory } from '../catalogue.component';
+import CatalogueItemsDialog from './catalogueItemsDialog.component';
 
 function CatalogueItemsLandingPage() {
   const { catalogue_item_id: catalogueItemId } = useParams();
-  const navigate = useNavigate();
-  const onChangeNode = React.useCallback(
-    (newIdPath: string) => {
-      navigate(`/catalogue/${newIdPath}`);
-    },
-    [navigate]
-  );
+  const navigateToCatalogueCategory = useNavigateToCatalogueCategory();
 
   const { data: catalogueItemIdData, isLoading: catalogueItemIdDataLoading } =
     useCatalogueItem(catalogueItemId);
 
   const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
-    catalogueItemIdData?.catalogue_category_id ?? ''
+    catalogueItemIdData?.catalogue_category_id ?? null
   );
   const { data: catalogueCategoryData } = useCatalogueCategory(
-    catalogueItemIdData?.catalogue_category_id
+    catalogueItemIdData?.catalogue_category_id ?? null
   );
 
   const [catalogueLandingBreadcrumbs, setCatalogueLandingBreadcrumbs] =
@@ -103,11 +98,9 @@ function CatalogueItemsLandingPage() {
       >
         <Grid item sx={{ py: '20px' }}>
           <Breadcrumbs
-            onChangeNode={onChangeNode}
+            onChangeNode={navigateToCatalogueCategory}
             breadcrumbsInfo={catalogueLandingBreadcrumbs}
-            onChangeNavigateHome={() => {
-              navigate('/catalogue');
-            }}
+            onChangeNavigateHome={() => navigateToCatalogueCategory(null)}
             navigateHomeAriaLabel={'navigate to catalogue home'}
           />
         </Grid>
@@ -342,7 +335,9 @@ function CatalogueItemsLandingPage() {
                           property.unit ? `(${property.unit})` : ''
                         }`}</Typography>
                         <Typography align="left" color="text.secondary">
-                          {property.value !== null ? String(property.value) : 'None'}
+                          {property.value !== null
+                            ? String(property.value)
+                            : 'None'}
                         </Typography>
                       </Grid>
                     ))}

--- a/src/catalogue/items/catalogueItemsLandingPage.component.tsx
+++ b/src/catalogue/items/catalogueItemsLandingPage.component.tsx
@@ -21,12 +21,12 @@ import { useCatalogueItem } from '../../api/catalogueItem';
 import { useManufacturer } from '../../api/manufacturer';
 import { BreadcrumbsInfo } from '../../app.types';
 import Breadcrumbs from '../../view/breadcrumbs.component';
-import { useNavigateToCatalogueCategory } from '../catalogue.component';
+import { useNavigateToCatalogue } from '../catalogue.component';
 import CatalogueItemsDialog from './catalogueItemsDialog.component';
 
 function CatalogueItemsLandingPage() {
   const { catalogue_item_id: catalogueItemId } = useParams();
-  const navigateToCatalogueCategory = useNavigateToCatalogueCategory();
+  const navigateToCatalogue = useNavigateToCatalogue();
 
   const { data: catalogueItemIdData, isLoading: catalogueItemIdDataLoading } =
     useCatalogueItem(catalogueItemId);
@@ -98,9 +98,9 @@ function CatalogueItemsLandingPage() {
       >
         <Grid item sx={{ py: '20px' }}>
           <Breadcrumbs
-            onChangeNode={navigateToCatalogueCategory}
+            onChangeNode={navigateToCatalogue}
             breadcrumbsInfo={catalogueLandingBreadcrumbs}
-            onChangeNavigateHome={() => navigateToCatalogueCategory(null)}
+            onChangeNavigateHome={() => navigateToCatalogue(null)}
             navigateHomeAriaLabel={'navigate to catalogue home'}
           />
         </Grid>

--- a/src/catalogue/items/catalogueItemsLandingPage.component.tsx
+++ b/src/catalogue/items/catalogueItemsLandingPage.component.tsx
@@ -32,10 +32,10 @@ function CatalogueItemsLandingPage() {
     useCatalogueItem(catalogueItemId);
 
   const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
-    catalogueItemIdData?.catalogue_category_id ?? null
+    catalogueItemIdData?.catalogue_category_id
   );
   const { data: catalogueCategoryData } = useCatalogueCategory(
-    catalogueItemIdData?.catalogue_category_id ?? null
+    catalogueItemIdData?.catalogue_category_id
   );
 
   const [catalogueLandingBreadcrumbs, setCatalogueLandingBreadcrumbs] =

--- a/src/catalogue/items/obsoleteCatalogueItemDialog.component.tsx
+++ b/src/catalogue/items/obsoleteCatalogueItemDialog.component.tsx
@@ -111,17 +111,15 @@ const ObsoleteCatalogueItemDialog = (
   }, [catalogueItem, handleObsoleteDetailChanged]);
 
   // Current category and its children
-  const { data: catalogueCategoryData } = useCatalogueCategory(
-    catalogueCurrDirId ?? undefined
-  );
+  const { data: catalogueCategoryData } =
+    useCatalogueCategory(catalogueCurrDirId);
   const {
     data: catalogueCategoryDataList,
     isLoading: catalogueCategoryDataListLoading,
   } = useCatalogueCategories(false, catalogueCurrDirId ?? 'null');
 
-  const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
-    catalogueCurrDirId ?? ''
-  );
+  const { data: catalogueBreadcrumbs } =
+    useCatalogueBreadcrumbs(catalogueCurrDirId);
   const { mutateAsync: editCatalogueItem } = useEditCatalogueItem();
 
   // Removes parameters when is_obsolete changed to false

--- a/src/items/deleteItemDialog.component.tsx
+++ b/src/items/deleteItemDialog.component.tsx
@@ -32,7 +32,7 @@ const DeleteItemDialog = (props: DeleteItemDialogProps) => {
     undefined
   );
 
-  const { data: systemData } = useSystem(item?.system_id ?? null);
+  const { data: systemData } = useSystem(item?.system_id);
   const { mutateAsync: deleteItem } = useDeleteItem();
 
   const handleClose = React.useCallback(() => {

--- a/src/items/itemDialog.component.test.tsx
+++ b/src/items/itemDialog.component.test.tsx
@@ -220,7 +220,7 @@ describe('ItemDialog', () => {
 
       await user.click(screen.getByRole('button', { name: 'Finish' }));
 
-      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items/', {
+      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items', {
         asset_number: null,
         catalogue_item_id: '1',
         delivered_date: null,
@@ -318,7 +318,7 @@ describe('ItemDialog', () => {
 
       await user.click(screen.getByRole('button', { name: 'Finish' }));
 
-      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items/', {
+      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items', {
         asset_number: null,
         catalogue_item_id: '17',
         delivered_date: null,
@@ -373,7 +373,7 @@ describe('ItemDialog', () => {
 
       await user.click(screen.getByRole('button', { name: 'Finish' }));
 
-      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items/', {
+      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items', {
         asset_number: 'test43',
         catalogue_item_id: '1',
         delivered_date: '2045-09-23T00:00:00.000Z',
@@ -484,7 +484,7 @@ describe('ItemDialog', () => {
 
       await user.click(screen.getByRole('button', { name: 'Finish' }));
 
-      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items/', {
+      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items', {
         asset_number: 'test43',
         catalogue_item_id: '1',
         delivered_date: '2045-09-23T00:00:00.000Z',
@@ -667,7 +667,7 @@ describe('ItemDialog', () => {
       await user.click(screen.getByRole('button', { name: 'Next' }));
       await user.click(screen.getByRole('button', { name: 'Finish' }));
 
-      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items/', {
+      expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items', {
         asset_number: '03MXnOfP5C',
         catalogue_item_id: '1',
         delivered_date: '2023-05-11T23:00:00.000Z',

--- a/src/items/items.component.tsx
+++ b/src/items/items.component.tsx
@@ -10,20 +10,17 @@ import {
 import ItemsTable from './itemsTable.component';
 import { BreadcrumbsInfo } from '../app.types';
 import Breadcrumbs from '../view/breadcrumbs.component';
+import { useNavigateToCatalogue } from '../catalogue/catalogue.component';
 
 export function Items() {
+  // Navigation
   const { catalogue_item_id: catalogueItemId } = useParams();
+  const navigateToCatalogue = useNavigateToCatalogue();
+
   const { data: catalogueItem, isLoading: catalogueItemLoading } =
     useCatalogueItem(catalogueItemId);
   const { data: catalogueCategory } = useCatalogueCategory(
     catalogueItem?.catalogue_category_id
-  );
-  const navigate = useNavigate();
-  const onChangeNode = React.useCallback(
-    (newIdPath: string) => {
-      navigate(`/catalogue/${newIdPath}`);
-    },
-    [navigate]
   );
 
   const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
@@ -65,11 +62,9 @@ export function Items() {
         }}
       >
         <Breadcrumbs
-          onChangeNode={onChangeNode}
+          onChangeNode={navigateToCatalogue}
           breadcrumbsInfo={itemsBreadcrumbs}
-          onChangeNavigateHome={() => {
-            navigate('/catalogue');
-          }}
+          onChangeNavigateHome={() => navigateToCatalogue(null)}
           navigateHomeAriaLabel={'navigate to catalogue home'}
         />
       </Grid>

--- a/src/items/items.component.tsx
+++ b/src/items/items.component.tsx
@@ -16,7 +16,7 @@ export function Items() {
   const { data: catalogueItem, isLoading: catalogueItemLoading } =
     useCatalogueItem(catalogueItemId);
   const { data: catalogueCategory } = useCatalogueCategory(
-    catalogueItem?.catalogue_category_id ?? null
+    catalogueItem?.catalogue_category_id
   );
   const navigate = useNavigate();
   const onChangeNode = React.useCallback(
@@ -27,7 +27,7 @@ export function Items() {
   );
 
   const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
-    catalogueItem?.catalogue_category_id ?? ''
+    catalogueItem?.catalogue_category_id
   );
 
   const [itemsBreadcrumbs, setItemsBreadcrumbs] = React.useState<

--- a/src/items/items.component.tsx
+++ b/src/items/items.component.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
 import { Box, Grid, LinearProgress, Typography } from '@mui/material';
-import { useCatalogueItem } from '../api/catalogueItem';
-import { useNavigate, useParams } from 'react-router-dom';
+import React from 'react';
+import { useParams } from 'react-router-dom';
 import {
   useCatalogueBreadcrumbs,
   useCatalogueCategory,
 } from '../api/catalogueCategory';
+import { useCatalogueItem } from '../api/catalogueItem';
 
-import ItemsTable from './itemsTable.component';
 import { BreadcrumbsInfo } from '../app.types';
-import Breadcrumbs from '../view/breadcrumbs.component';
 import { useNavigateToCatalogue } from '../catalogue/catalogue.component';
+import Breadcrumbs from '../view/breadcrumbs.component';
+import ItemsTable from './itemsTable.component';
 
 export function Items() {
   // Navigation

--- a/src/items/items.component.tsx
+++ b/src/items/items.component.tsx
@@ -16,7 +16,7 @@ export function Items() {
   const { data: catalogueItem, isLoading: catalogueItemLoading } =
     useCatalogueItem(catalogueItemId);
   const { data: catalogueCategory } = useCatalogueCategory(
-    catalogueItem?.catalogue_category_id
+    catalogueItem?.catalogue_category_id ?? null
   );
   const navigate = useNavigate();
   const onChangeNode = React.useCallback(

--- a/src/items/itemsLandingPage.component.tsx
+++ b/src/items/itemsLandingPage.component.tsx
@@ -35,7 +35,7 @@ function ItemsLandingPage() {
   );
 
   const { data: catalogueCategoryData } = useCatalogueCategory(
-    catalogueItemData?.catalogue_category_id
+    catalogueItemData?.catalogue_category_id ?? null
   );
 
   const navigate = useNavigate();
@@ -47,7 +47,7 @@ function ItemsLandingPage() {
   );
 
   const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
-    catalogueItemData?.catalogue_category_id ?? ''
+    catalogueItemData?.catalogue_category_id ?? null
   );
 
   const [itemLandingBreadcrumbs, setItemLandingBreadcrumbs] = React.useState<
@@ -315,7 +315,9 @@ function ItemsLandingPage() {
                           property.unit ? `(${property.unit})` : ''
                         }`}</Typography>
                         <Typography align="left" color="text.secondary">
-                          {property.value !== null ? String(property.value) : 'None'}
+                          {property.value !== null
+                            ? String(property.value)
+                            : 'None'}
                         </Typography>
                       </Grid>
                     ))}

--- a/src/items/itemsLandingPage.component.tsx
+++ b/src/items/itemsLandingPage.component.tsx
@@ -35,7 +35,7 @@ function ItemsLandingPage() {
   );
 
   const { data: catalogueCategoryData } = useCatalogueCategory(
-    catalogueItemData?.catalogue_category_id ?? null
+    catalogueItemData?.catalogue_category_id
   );
 
   const navigate = useNavigate();
@@ -47,7 +47,7 @@ function ItemsLandingPage() {
   );
 
   const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
-    catalogueItemData?.catalogue_category_id ?? null
+    catalogueItemData?.catalogue_category_id
   );
 
   const [itemLandingBreadcrumbs, setItemLandingBreadcrumbs] = React.useState<

--- a/src/items/itemsLandingPage.component.tsx
+++ b/src/items/itemsLandingPage.component.tsx
@@ -1,7 +1,7 @@
+import EditIcon from '@mui/icons-material/Edit';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import PrintIcon from '@mui/icons-material/Print';
-import EditIcon from '@mui/icons-material/Edit';
 import {
   Box,
   Button,
@@ -12,21 +12,24 @@ import {
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import React, { useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 
-import { useCatalogueItem } from '../api/catalogueItem';
-import { useManufacturer } from '../api/manufacturer';
-import { useItem } from '../api/item';
-import { BreadcrumbsInfo, UsageStatusType } from '../app.types';
 import {
   useCatalogueBreadcrumbs,
   useCatalogueCategory,
 } from '../api/catalogueCategory';
+import { useCatalogueItem } from '../api/catalogueItem';
+import { useItem } from '../api/item';
+import { useManufacturer } from '../api/manufacturer';
+import { BreadcrumbsInfo, UsageStatusType } from '../app.types';
 import Breadcrumbs from '../view/breadcrumbs.component';
 import ItemDialog from './itemDialog.component';
+import { useNavigateToCatalogue } from '../catalogue/catalogue.component';
 
 function ItemsLandingPage() {
+  // Navigation
   const { item_id: id } = useParams();
+  const navigateToCatalogue = useNavigateToCatalogue();
 
   const { data: itemData, isLoading: itemDataIsLoading } = useItem(id);
 
@@ -36,14 +39,6 @@ function ItemsLandingPage() {
 
   const { data: catalogueCategoryData } = useCatalogueCategory(
     catalogueItemData?.catalogue_category_id
-  );
-
-  const navigate = useNavigate();
-  const onChangeNode = React.useCallback(
-    (newIdPath: string) => {
-      navigate(`/catalogue/${newIdPath}`);
-    },
-    [navigate]
   );
 
   const { data: catalogueBreadcrumbs } = useCatalogueBreadcrumbs(
@@ -113,11 +108,9 @@ function ItemsLandingPage() {
       >
         <Grid item sx={{ py: 2.5 }}>
           <Breadcrumbs
-            onChangeNode={onChangeNode}
+            onChangeNode={navigateToCatalogue}
             breadcrumbsInfo={itemLandingBreadcrumbs}
-            onChangeNavigateHome={() => {
-              navigate('/catalogue');
-            }}
+            onChangeNavigateHome={() => navigateToCatalogue(null)}
             navigateHomeAriaLabel={'navigate to catalogue home'}
           />
         </Grid>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -113,7 +113,7 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(data));
   }),
 
-  rest.get('/v1/catalogue-categories/', (req, res, ctx) => {
+  rest.get('/v1/catalogue-categories', (req, res, ctx) => {
     const catalogueCategoryParams = req.url.searchParams;
     const parentId = catalogueCategoryParams.get('parent_id');
     let data;
@@ -186,7 +186,7 @@ export const handlers = [
       return res(ctx.status(400), ctx.json(''));
     }
   }),
-  rest.post('/v1/catalogue-items/', async (req, res, ctx) => {
+  rest.post('/v1/catalogue-items', async (req, res, ctx) => {
     const body = (await req.json()) as CatalogueItem;
 
     if (
@@ -205,7 +205,7 @@ export const handlers = [
     );
   }),
 
-  rest.get('/v1/catalogue-items/', async (req, res, ctx) => {
+  rest.get('/v1/catalogue-items', async (req, res, ctx) => {
     const catalogueItemsParams = req.url.searchParams;
     const id = catalogueItemsParams.get('catalogue_category_id');
 
@@ -479,7 +479,7 @@ export const handlers = [
     }
   }),
   // ------------------------------------ ITEMS ------------------------------------------------
-  rest.post('/v1/items/', async (req, res, ctx) => {
+  rest.post('/v1/items', async (req, res, ctx) => {
     const body = (await req.json()) as AddItem;
 
     if (body.serial_number === 'Error 500') {
@@ -495,7 +495,7 @@ export const handlers = [
     );
   }),
 
-  rest.get('/v1/items/', (req, res, ctx) => {
+  rest.get('/v1/items', (req, res, ctx) => {
     const itemsParams = req.url.searchParams;
     const catalogueItemId = itemsParams.get('catalogue_item_id');
     const systemId = itemsParams.get('system_id');
@@ -535,8 +535,7 @@ export const handlers = [
       return res(
         ctx.status(409),
         ctx.json({
-          detail:
-            'The specified system ID does not exist',
+          detail: 'The specified system ID does not exist',
         })
       );
 

--- a/src/systems/systems.component.tsx
+++ b/src/systems/systems.component.tsx
@@ -57,6 +57,18 @@ export const useNavigateToSystem = () => {
   );
 };
 
+/* Returns the system id from the location pathname (null when not found) */
+export const useSystemId = (): string | null => {
+  // Navigation setup
+  const location = useLocation();
+
+  return React.useMemo(() => {
+    let systemId: string | null = location.pathname.replace('/systems', '');
+    systemId = systemId === '' ? null : systemId.replace('/', '');
+    return systemId;
+  }, [location.pathname]);
+};
+
 const AddSystemButton = (props: { systemId: string | null }) => {
   const [addSystemDialogOpen, setAddSystemDialogOpen] =
     React.useState<boolean>(false);
@@ -140,18 +152,6 @@ const CopySystemsButton = (props: {
 };
 
 type MenuDialogType = SystemDialogType | 'delete';
-
-/* Returns the system id from the location pathname (null when not found) */
-export const useSystemId = (): string | null => {
-  // Navigation setup
-  const location = useLocation();
-
-  return React.useMemo(() => {
-    let systemId: string | null = location.pathname.replace('/systems', '');
-    systemId = systemId === '' ? null : systemId.replace('/', '');
-    return systemId;
-  }, [location.pathname]);
-};
 
 const columns: MRT_ColumnDef<System>[] = [
   {
@@ -300,9 +300,7 @@ function Systems() {
             <Breadcrumbs
               breadcrumbsInfo={systemsBreadcrumbs}
               onChangeNode={navigateToSystem}
-              onChangeNavigateHome={() => {
-                navigateToSystem(null);
-              }}
+              onChangeNavigateHome={() => navigateToSystem(null)}
               navigateHomeAriaLabel={'navigate to systems home'}
             />
             {systemsBreadcrumbs && (


### PR DESCRIPTION
## Description

Removes trailing slashes on API urls. They will also be removed on the backend to stop the 307 redirect's that break the production docker version.

Also makes a modification to what we define as the id for a root catalogue category. Previously we had some queries being disabled for `id !== ""` and some for `id !== undefined"`. So I modified all of them to be the same, either "null" or "undefined" to be consistent. This prevents some unnecessary requests from being sent and most importantly one for the `catalogue-items/` in `useCatalogueCategory` when at the root. A change from this also broke some tests that shouldn't really have worked in the first place so I fixed those here too.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

