### PR TITLE
Use is pending disable buttons #325

### DIFF
--- a/src/catalogue/category/catalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.tsx
@@ -94,8 +94,10 @@ const CatalogueCategoryDialog = React.memo(
     const [allowedValuesListErrors, setAllowedValuesListErrors] =
       React.useState<AllowedValuesListErrorsType[]>([]);
 
-    const { mutateAsync: addCatalogueCategory } = useAddCatalogueCategory();
-    const { mutateAsync: editCatalogueCategory } = useEditCatalogueCategory();
+    const { mutateAsync: addCatalogueCategory, isPending: isAddPending } =
+      useAddCatalogueCategory();
+    const { mutateAsync: editCatalogueCategory, isPending: isEditPending } =
+      useEditCatalogueCategory();
 
     const [catalogueItemPropertiesErrors, setCatalogueItemPropertiesErrors] =
       React.useState<CatalogueItemPropertiesErrorsType[]>([]);
@@ -134,7 +136,6 @@ const CatalogueCategoryDialog = React.memo(
           const trimmedLowerCaseValues = listOfValues.map((value) =>
             String(value).trim().toLowerCase()
           );
-
 
           const duplicateIndexes: number[] = [];
           const invalidNumberIndexes: number[] = [];
@@ -607,6 +608,8 @@ const CatalogueCategoryDialog = React.memo(
                   : handleAddCatalogueCategory
               }
               disabled={
+                isEditPending ||
+                isAddPending ||
                 formError !== undefined ||
                 nameError !== undefined ||
                 catalogueItemPropertiesErrors.length !== 0 ||

--- a/src/catalogue/category/catalogueCategoryDirectoryDialog.component.tsx
+++ b/src/catalogue/category/catalogueCategoryDirectoryDialog.component.tsx
@@ -64,8 +64,10 @@ const CatalogueCategoryDirectoryDialog = (
     setParentCategoryId(props.parentCategoryId);
   }, [onClose, props.parentCategoryId]);
 
-  const { mutateAsync: moveToCatalogueCategory } = useMoveToCatalogueCategory();
-  const { mutateAsync: copyToCatalogueCategory } = useCopyToCatalogueCategory();
+  const { mutateAsync: moveToCatalogueCategory, isPending: isMoveToPending } =
+    useMoveToCatalogueCategory();
+  const { mutateAsync: copyToCatalogueCategory, isPending: isCopyToPending } =
+    useCopyToCatalogueCategory();
 
   const { data: targetCategory, isLoading: targetCategoryLoading } =
     useCatalogueCategory(parentCategoryId);
@@ -193,7 +195,7 @@ const CatalogueCategoryDirectoryDialog = (
         <Button onClick={handleClose}>Cancel</Button>
         <Button
           disabled={
-            requestType === 'moveTo'
+            isCopyToPending || isMoveToPending || requestType === 'moveTo'
               ? selectedCategories.length > 0
                 ? parentCategoryId === selectedCategories[0].parent_id
                 : false

--- a/src/catalogue/category/deleteCatalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/deleteCatalogueCategoryDialog.component.tsx
@@ -33,7 +33,8 @@ const DeleteCatalogueCategoryDialog = (
     undefined
   );
 
-  const { mutateAsync: deleteCatalogueCategory } = useDeleteCatalogueCategory();
+  const { mutateAsync: deleteCatalogueCategory, isPending: isDeletePending } =
+    useDeleteCatalogueCategory();
 
   const handleClose = React.useCallback(() => {
     onClose();
@@ -84,7 +85,10 @@ const DeleteCatalogueCategoryDialog = (
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleDeleteCatalogueCategory} disabled={error}>
+        <Button
+          onClick={handleDeleteCatalogueCategory}
+          disabled={isDeletePending || error}
+        >
           Continue
         </Button>
       </DialogActions>

--- a/src/catalogue/items/catalogueItemDirectoryDialog.component.tsx
+++ b/src/catalogue/items/catalogueItemDirectoryDialog.component.tsx
@@ -76,8 +76,10 @@ const CatalogueItemDirectoryDialog = (
     setErrorMessage('');
   }, [parentCategoryId]);
 
-  const { mutateAsync: moveToCatalogueItem } = useMoveToCatalogueItem();
-  const { mutateAsync: copyToCatalogueItem } = useCopyToCatalogueItem();
+  const { mutateAsync: moveToCatalogueItem, isPending: isMoveToPending } =
+    useMoveToCatalogueItem();
+  const { mutateAsync: copyToCatalogueItem, isPending: isCopyToPending } =
+    useCopyToCatalogueItem();
 
   const { data: targetCatalogueCategory } =
     useCatalogueCategory(parentCategoryId);
@@ -208,7 +210,7 @@ const CatalogueItemDirectoryDialog = (
         <Button onClick={handleClose}>Cancel</Button>
         <Button
           disabled={
-            requestType === 'moveTo'
+            isCopyToPending || isMoveToPending || requestType === 'moveTo'
               ? !(
                   (targetCatalogueCategory?.is_leaf ?? false) &&
                   parentCategoryId !== parentInfo.id

--- a/src/catalogue/items/catalogueItemsDialog.component.tsx
+++ b/src/catalogue/items/catalogueItemsDialog.component.tsx
@@ -200,8 +200,10 @@ function CatalogueItemsDialog(props: CatalogueItemsDialogProps) {
     setPropertyErrors(updatedPropertyErrors);
   };
 
-  const { mutateAsync: addCatalogueItem } = useAddCatalogueItem();
-  const { mutateAsync: editCatalogueItem } = useEditCatalogueItem();
+  const { mutateAsync: addCatalogueItem, isPending: isAddPending } =
+    useAddCatalogueItem();
+  const { mutateAsync: editCatalogueItem, isPending: isEditPending } =
+    useEditCatalogueItem();
 
   const { data: manufacturerList } = useManufacturers();
   const selectedCatalogueItemManufacturer =
@@ -1080,6 +1082,8 @@ function CatalogueItemsDialog(props: CatalogueItemsDialogProps) {
         {activeStep === STEPS.length - 1 ? (
           <Button
             disabled={
+              isEditPending ||
+              isAddPending ||
               JSON.stringify(errorMessages) !== '{}' ||
               formError ||
               propertyErrors.some((value) => {

--- a/src/catalogue/items/deleteCatalogueItemDialog.component.tsx
+++ b/src/catalogue/items/deleteCatalogueItemDialog.component.tsx
@@ -29,7 +29,8 @@ const DeleteCatalogueItemDialog = (props: DeleteCatalogueItemDialogProps) => {
     undefined
   );
 
-  const { mutateAsync: deleteCatalogueItem } = useDeleteCatalogueItem();
+  const { mutateAsync: deleteCatalogueItem, isPending: isDeletePending } =
+    useDeleteCatalogueItem();
 
   const handleClose = React.useCallback(() => {
     onClose();
@@ -75,7 +76,10 @@ const DeleteCatalogueItemDialog = (props: DeleteCatalogueItemDialogProps) => {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleDeleteCatalogueCategory} disabled={error}>
+        <Button
+          onClick={handleDeleteCatalogueCategory}
+          disabled={isDeletePending || error}
+        >
           Continue
         </Button>
       </DialogActions>

--- a/src/catalogue/items/obsoleteCatalogueItemDialog.component.tsx
+++ b/src/catalogue/items/obsoleteCatalogueItemDialog.component.tsx
@@ -118,7 +118,8 @@ const ObsoleteCatalogueItemDialog = (
 
   const { data: catalogueBreadcrumbs } =
     useCatalogueBreadcrumbs(catalogueCurrDirId);
-  const { mutateAsync: editCatalogueItem } = useEditCatalogueItem();
+  const { mutateAsync: editCatalogueItem, isPending: isEditPending } =
+    useEditCatalogueItem();
 
   // Removes parameters when is_obsolete changed to false
   const handleObsoleteChange = (isObsolete: boolean) => {
@@ -319,7 +320,10 @@ const ObsoleteCatalogueItemDialog = (
           Back
         </Button>
         {activeStep === steps.length - 1 ? (
-          <Button onClick={handleFinish} disabled={formError !== undefined}>
+          <Button
+            onClick={handleFinish}
+            disabled={isEditPending || formError !== undefined}
+          >
             Finish
           </Button>
         ) : (

--- a/src/items/deleteItemDialog.component.tsx
+++ b/src/items/deleteItemDialog.component.tsx
@@ -34,7 +34,8 @@ const DeleteItemDialog = (props: DeleteItemDialogProps) => {
   );
 
   const { data: systemData } = useSystem(item?.system_id);
-  const { mutateAsync: deleteItem } = useDeleteItem();
+  const { mutateAsync: deleteItem, isPending: isDeletePending } =
+    useDeleteItem();
 
   const handleClose = React.useCallback(() => {
     onClose();
@@ -87,7 +88,7 @@ const DeleteItemDialog = (props: DeleteItemDialogProps) => {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleDeleteItem} disabled={error}>
+        <Button onClick={handleDeleteItem} disabled={isDeletePending || error}>
           Continue
         </Button>
       </DialogActions>

--- a/src/items/itemDialog.component.tsx
+++ b/src/items/itemDialog.component.tsx
@@ -142,8 +142,8 @@ function ItemDialog(props: ItemDialogProps) {
     string | undefined
   >(undefined);
 
-  const { mutateAsync: addItem } = useAddItem();
-  const { mutateAsync: editItem } = useEditItem();
+  const { mutateAsync: addItem, isPending: isAddPending } = useAddItem();
+  const { mutateAsync: editItem, isPending: isEditPending } = useEditItem();
 
   React.useEffect(() => {
     if (type === 'create' && open) {
@@ -918,6 +918,8 @@ function ItemDialog(props: ItemDialogProps) {
         {activeStep === STEPS.length - 1 ? (
           <Button
             disabled={
+              isAddPending ||
+              isEditPending ||
               !itemDetails.system_id ||
               formErrorMessage !== undefined ||
               propertyErrors.some((value) => value === true) ||

--- a/src/manufacturer/deleteManufacturerDialog.component.tsx
+++ b/src/manufacturer/deleteManufacturerDialog.component.tsx
@@ -28,7 +28,8 @@ const DeleteManufacturerDialog = (props: DeleteManufacturerProps) => {
     undefined
   );
 
-  const { mutateAsync: deleteManufacturer } = useDeleteManufacturer();
+  const { mutateAsync: deleteManufacturer, isPending: isDeletePending } =
+    useDeleteManufacturer();
 
   const handleClose = React.useCallback(() => {
     onClose();
@@ -74,7 +75,10 @@ const DeleteManufacturerDialog = (props: DeleteManufacturerProps) => {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleDeleteManufacturer} disabled={error}>
+        <Button
+          onClick={handleDeleteManufacturer}
+          disabled={isDeletePending || error}
+        >
           Continue
         </Button>
       </DialogActions>

--- a/src/manufacturer/manufacturerDialog.component.tsx
+++ b/src/manufacturer/manufacturerDialog.component.tsx
@@ -90,8 +90,10 @@ function ManufacturerDialog(props: ManufacturerDialogProps) {
     undefined
   );
 
-  const { mutateAsync: addManufacturer } = useAddManufacturer();
-  const { mutateAsync: editManufacturer } = useEditManufacturer();
+  const { mutateAsync: addManufacturer, isPending: isAddPending } =
+    useAddManufacturer();
+  const { mutateAsync: editManufacturer, isPending: isEditPending } =
+    useEditManufacturer();
   const { data: selectedManufacturerData } = useManufacturer(
     selectedManufacturer?.id
   );
@@ -541,6 +543,8 @@ function ManufacturerDialog(props: ManufacturerDialogProps) {
               type === 'create' ? handleAddManufacturer : handleEditManufacturer
             }
             disabled={
+              isAddPending ||
+              isEditPending ||
               formError !== undefined ||
               nameError !== undefined ||
               urlError !== undefined ||

--- a/src/systems/deleteSystemDialog.component.tsx
+++ b/src/systems/deleteSystemDialog.component.tsx
@@ -27,7 +27,8 @@ export const DeleteSystemDialog = (props: DeleteSystemDialogProps) => {
     undefined
   );
 
-  const { mutateAsync: deleteSystem } = useDeleteSystem();
+  const { mutateAsync: deleteSystem, isPending: isDeletePending } =
+    useDeleteSystem();
 
   const handleClose = () => {
     onClose();
@@ -67,7 +68,7 @@ export const DeleteSystemDialog = (props: DeleteSystemDialogProps) => {
         <Button onClick={handleClose}>Cancel</Button>
         <Button
           onClick={handleDeleteSystem}
-          disabled={errorMessage !== undefined}
+          disabled={isDeletePending || errorMessage !== undefined}
         >
           Continue
         </Button>

--- a/src/systems/systemDialog.component.tsx
+++ b/src/systems/systemDialog.component.tsx
@@ -91,8 +91,8 @@ const SystemDialog = React.memo((props: SystemDialogProps) => {
     onClose();
   }, [onClose, selectedSystem, type]);
 
-  const { mutateAsync: addSystem } = useAddSystem();
-  const { mutateAsync: editSystem } = useEditSystem();
+  const { mutateAsync: addSystem, isPending: isAddPending } = useAddSystem();
+  const { mutateAsync: editSystem, isPending: isEditPending } = useEditSystem();
 
   // Returns true when all fields valid
   const validateFields = React.useCallback((): boolean => {
@@ -315,7 +315,12 @@ const SystemDialog = React.memo((props: SystemDialogProps) => {
             variant="outlined"
             sx={{ width: '50%', mx: 1 }}
             onClick={type === 'edit' ? handleEditSystem : handleAddSaveSystem}
-            disabled={formError !== undefined || nameError !== undefined}
+            disabled={
+              isAddPending ||
+              isEditPending ||
+              formError !== undefined ||
+              nameError !== undefined
+            }
           >
             Save
           </Button>

--- a/src/systems/systemDirectoryDialog.component.tsx
+++ b/src/systems/systemDirectoryDialog.component.tsx
@@ -55,8 +55,10 @@ export const SystemDirectoryDialog = (props: SystemDirectoryDialogProps) => {
   const { data: targetSystem, isLoading: targetSystemLoading } =
     useSystem(parentSystemId);
 
-  const { mutateAsync: moveToSystem } = useMoveToSystem();
-  const { mutateAsync: copyToSystem } = useCopyToSystem();
+  const { mutateAsync: moveToSystem, isPending: isMovePending } =
+    useMoveToSystem();
+  const { mutateAsync: copyToSystem, isPending: isCopyPending } =
+    useCopyToSystem();
 
   const handleClose = React.useCallback(() => {
     onClose();
@@ -180,8 +182,10 @@ export const SystemDirectoryDialog = (props: SystemDirectoryDialogProps) => {
         <Button onClick={handleClose}>Cancel</Button>
         <Button
           disabled={
+            isCopyPending ||
+            isMovePending ||
             // Disable when not moving anywhere different
-            props.parentSystemId === parentSystemId && type === 'moveTo'
+            (props.parentSystemId === parentSystemId && type === 'moveTo')
           }
           onClick={type === 'moveTo' ? handleMoveTo : handleCopyTo}
         >

--- a/src/systems/systemItemsDialog.component.tsx
+++ b/src/systems/systemItemsDialog.component.tsx
@@ -45,7 +45,8 @@ const SystemItemsDialog = React.memo((props: SystemItemsDialogProps) => {
   const { data: targetSystem, isLoading: targetSystemLoading } =
     useSystem(parentSystemId);
 
-  const { mutateAsync: moveItemsToSystem } = useMoveItemsToSystem();
+  const { mutateAsync: moveItemsToSystem, isPending: isMovePending } =
+    useMoveItemsToSystem();
 
   const handleClose = React.useCallback(() => {
     onClose();
@@ -112,9 +113,11 @@ const SystemItemsDialog = React.memo((props: SystemItemsDialogProps) => {
         <Button onClick={onClose}>Cancel</Button>
         <Button
           disabled={
+            isMovePending ||
             // Disable when not moving anywhere different
             // or when attempting to move to root i.e. no system
-            props.parentSystemId === parentSystemId || parentSystemId === null
+            props.parentSystemId === parentSystemId ||
+            parentSystemId === null
           }
           onClick={handleMoveTo}
         >


### PR DESCRIPTION
## Description

Implemented `isPending` when requests are made so that buttons then become disabled. This ensures users cannot send multiple requests by continuously clicking on the button

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

closes #325
