### PR TITLE
Remove react-query stale time

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,6 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: true,
-      staleTime: 300000,
       retry: (failureCount, error) => {
         return retryIMS_APIErrors(failureCount, error as AxiosError);
       },


### PR DESCRIPTION
## Description

Removes the global staleTime in react query so that it uses its default of 0. This means that when navigating back to a previously viewed entity, the get request will be sent again. This should help to ensure data is kept refreshed when multiple users using the site simultaneously.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #321 
