### PR TITLE
Fix unit test warning in viewTabs #377

### DIFF
--- a/src/app.types.tsx
+++ b/src/app.types.tsx
@@ -1,7 +1,8 @@
 export const MicroFrontendId = 'scigateway';
 export const MicroFrontendToken = `${MicroFrontendId}:token`;
 
-export type TabValue = 'Systems' | 'Catalogue' | 'Manufacturers';
+export const TAB_VALUES = ['Catalogue', 'Systems', 'Manufacturers'] as const;
+export type TabValue = (typeof TAB_VALUES)[number];
 
 export interface AddCatalogueCategory {
   name: string;

--- a/src/view/viewTabs.component.tsx
+++ b/src/view/viewTabs.component.tsx
@@ -4,7 +4,7 @@ import Tabs from '@mui/material/Tabs';
 import { styled } from '@mui/material/styles';
 import React from 'react';
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
-import { TabValue } from '../app.types';
+import { TAB_VALUES, TabValue } from '../app.types';
 import Catalogue from '../catalogue/catalogue.component';
 import CatalogueItemsLandingPage from '../catalogue/items/catalogueItemsLandingPage.component';
 import Items from '../items/items.component';
@@ -29,8 +29,8 @@ export const paths = {
 
 interface TabPanelProps {
   children?: React.ReactNode;
-  value: TabValue;
-  label: TabValue;
+  value: TabValue | false;
+  label: TabValue | false;
 }
 
 function TabPanel(props: TabPanelProps) {
@@ -63,7 +63,7 @@ const StyledTab = styled(Tab)(({ theme }) => ({
 }));
 
 function ViewTabs() {
-  const [value, setValue] = React.useState<TabValue>('Catalogue');
+  const [value, setValue] = React.useState<TabValue | false>('Catalogue');
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -81,8 +81,10 @@ function ViewTabs() {
 
       if (tabValue !== value && tabValue !== '') {
         tabValue = tabValue.charAt(0).toUpperCase() + tabValue.slice(1);
-        setValue(tabValue as TabValue);
-      }
+        if (TAB_VALUES.includes(tabValue as TabValue))
+          setValue(tabValue as TabValue);
+        else setValue(false);
+      } else setValue(false);
     }
   }, [location.pathname, value]);
 
@@ -118,21 +120,14 @@ function ViewTabs() {
       {isRunningInDevelopment() ? (
         <>
           <Tabs value={value} onChange={handleChange} aria-label="view tabs">
-            <StyledTab
-              value="Catalogue"
-              label="Catalogue"
-              {...a11yProps('Catalogue')}
-            />
-            <StyledTab
-              value="Systems"
-              label="Systems"
-              {...a11yProps('Systems')}
-            />
-            <StyledTab
-              value="Manufacturers"
-              label="Manufacturers"
-              {...a11yProps('Manufacturers')}
-            />
+            {TAB_VALUES.map((value) => (
+              <StyledTab
+                value={value}
+                label={value}
+                key={value}
+                {...a11yProps(value)}
+              />
+            ))}
           </Tabs>
           <Box
             sx={{


### PR DESCRIPTION
## Description

Fixes a warning in the unit tests caused by viewTabs when the tabValue is computed to be "Ims" for the homepage. Allowed the value to be false (so no tab is selected) whenever it is invalid.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #377
