### PR TITLE
Add missing awaits for user.click in unit tests

### DIFF
--- a/src/catalogue/category/cataloguePropertiesForm.component.test.tsx
+++ b/src/catalogue/category/cataloguePropertiesForm.component.test.tsx
@@ -81,7 +81,7 @@ describe('Catalogue Properties Form', () => {
     createView();
 
     // Click on the add button
-    user.click(
+    await user.click(
       screen.getByRole('button', { name: 'Add catalogue category field entry' })
     );
 
@@ -105,7 +105,7 @@ describe('Catalogue Properties Form', () => {
     createView();
 
     // Click on the add button
-    user.click(screen.getAllByTestId('DeleteIcon')[0]);
+    await user.click(screen.getAllByTestId('DeleteIcon')[0]);
 
     await waitFor(() => {
       expect(onChangeFormFields).toHaveBeenCalledWith([

--- a/src/catalogue/category/deleteCatalogueCategoryDialog.component.test.tsx
+++ b/src/catalogue/category/deleteCatalogueCategoryDialog.component.test.tsx
@@ -78,7 +78,7 @@ describe('delete Catalogue Category dialogue', () => {
   it('calls handleDeleteSession when continue button is clicked with a valid session name', async () => {
     createView();
     const continueButton = screen.getByRole('button', { name: 'Continue' });
-    user.click(continueButton);
+    await user.click(continueButton);
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();
@@ -89,7 +89,7 @@ describe('delete Catalogue Category dialogue', () => {
     catalogueCategory.id = '2';
     createView();
     const continueButton = screen.getByRole('button', { name: 'Continue' });
-    user.click(continueButton);
+    await user.click(continueButton);
 
     await waitFor(() => {
       expect(

--- a/src/catalogue/items/deleteCatalogueItemDialog.component.test.tsx
+++ b/src/catalogue/items/deleteCatalogueItemDialog.component.test.tsx
@@ -78,7 +78,7 @@ describe('delete Catalogue Category dialogue', () => {
   it('calls handleDeleteSession when continue button is clicked with a valid session name', async () => {
     createView();
     const continueButton = screen.getByRole('button', { name: 'Continue' });
-    user.click(continueButton);
+    await user.click(continueButton);
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();
@@ -89,7 +89,7 @@ describe('delete Catalogue Category dialogue', () => {
     catalogueItem.id = '6';
     createView();
     const continueButton = screen.getByRole('button', { name: 'Continue' });
-    user.click(continueButton);
+    await user.click(continueButton);
 
     await waitFor(() => {
       expect(

--- a/src/items/deleteItemDialog.component.test.tsx
+++ b/src/items/deleteItemDialog.component.test.tsx
@@ -84,7 +84,7 @@ describe('delete item dialog', () => {
   it('calls handleDeleteSession when continue button is clicked with a valid session name', async () => {
     createView();
     const continueButton = screen.getByRole('button', { name: 'Continue' });
-    user.click(continueButton);
+    await user.click(continueButton);
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();


### PR DESCRIPTION
## Description

Noticed a warning in https://github.com/ral-facilities/inventory-management-system/actions/runs/8249904474/job/22563345507, caused by not having an await on a user.click, so found all that were missing and added them in here.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
