### PR TITLE
Fix incorrect type in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -119,7 +119,7 @@ export default defineConfig(({ mode }) => {
   return {
     ...config,
     test: {
-      globals: 'true',
+      globals: true,
       environment: 'jsdom',
       globalSetup: './globalSetup.js',
       setupFiles: ['src/setupTests.tsx'],


### PR DESCRIPTION
## Description

Type hinting doesn't appear to work properly in vscode when splitting up the config like this, so I only noticed it while migrating SciGateway. As it was a non-empty string it would still have been evaluated to true so shouldn't have had any effect.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
