### PR TITLE
stop-CC-query-at-/-#402

### DIFF
--- a/src/catalogue/catalogue.component.tsx
+++ b/src/catalogue/catalogue.component.tsx
@@ -209,11 +209,12 @@ function Catalogue() {
   } = useCatalogueCategories(
     catalogueCategoryDetailLoading ? true : !!parentInfo && parentInfo.is_leaf,
     // String value of null for filtering root catalogue category
-    catalogueCategoryId === null ? 'null' : catalogueCategoryId
+    !catalogueCategoryId ? 'null' : catalogueCategoryId
   );
 
-  const catalogueCategoryNames: string[] =
-    catalogueCategoryData?.map((item) => item.name) || [];
+  const catalogueCategoryNames: string[] = catalogueCategoryData
+    ? catalogueCategoryData.map((item) => item.name)
+    : [];
 
   const [deleteCategoryDialogOpen, setDeleteCategoryDialogOpen] =
     React.useState<boolean>(false);

--- a/src/systems/systems.component.tsx
+++ b/src/systems/systems.component.tsx
@@ -63,8 +63,11 @@ export const useSystemId = (): string | null => {
   const location = useLocation();
 
   return React.useMemo(() => {
-    let systemId: string | null = location.pathname.replace('/systems', '');
-    systemId = systemId === '' ? null : systemId.replace('/', '');
+    let systemId: string | null = location.pathname
+      .replace('/systems', '')
+      // In case of /systems/
+      .replace('/', '');
+    systemId = systemId === '' ? null : systemId;
     return systemId;
   }, [location.pathname]);
 };


### PR DESCRIPTION
## Description

stops the catalogue category query from setting the id to empty string. Changes this default to "null" (i.e. "null")
fix error when catalogue category data is undefined 

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes #402
