### PR TITLE
fixed bugs in systems and catalogue items directory dialogs #403

### DIFF
--- a/src/catalogue/items/catalogueItemDirectoryDialog.component.tsx
+++ b/src/catalogue/items/catalogueItemDirectoryDialog.component.tsx
@@ -208,6 +208,7 @@ const CatalogueItemDirectoryDialog = (
             catalogueCategoryDataLoading={catalogueCategoryDataLoading}
             requestOrigin="item"
             catalogueItemParentCategory={parentInfo}
+            catalogueCategoryParentId={parentCategoryId ?? undefined}
           />
         )}
       </DialogContent>

--- a/src/systems/systemItemsDialog.component.tsx
+++ b/src/systems/systemItemsDialog.component.tsx
@@ -104,6 +104,7 @@ const SystemItemsDialog = React.memo((props: SystemItemsDialogProps) => {
           systemsData={systemsData}
           systemsDataLoading={systemsDataLoading}
           onChangeParentId={setParentSystemId}
+          systemParentId={props.parentSystemId ?? undefined}
           // Use most unrestricted variant (i.e. copy with no selection)
           selectedSystems={[]}
           type="copyTo"

--- a/src/systems/systemItemsDialog.component.tsx
+++ b/src/systems/systemItemsDialog.component.tsx
@@ -104,7 +104,7 @@ const SystemItemsDialog = React.memo((props: SystemItemsDialogProps) => {
           systemsData={systemsData}
           systemsDataLoading={systemsDataLoading}
           onChangeParentId={setParentSystemId}
-          systemParentId={props.parentSystemId ?? undefined}
+          systemParentId={parentSystemId ?? undefined}
           // Use most unrestricted variant (i.e. copy with no selection)
           selectedSystems={[]}
           type="copyTo"


### PR DESCRIPTION
## Description

Fixed bug where adding a system/catalogue category in a directory dialog adds them to the root instead of as a child of the system/catalogue category

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

closes #403
