### PR TITLE
Tweak subsystems per page

### DIFF
--- a/src/systems/systems.component.tsx
+++ b/src/systems/systems.component.tsx
@@ -222,7 +222,7 @@ function Systems() {
     // State
     initialState: {
       showGlobalFilter: true,
-      pagination: { pageSize: 10, pageIndex: 0 },
+      pagination: { pageSize: 15, pageIndex: 0 },
     },
     state: { rowSelection: rowSelection },
     // MUI
@@ -231,7 +231,7 @@ function Systems() {
       shape: 'rounded',
       variant: 'outlined',
       showRowsPerPage: true,
-      rowsPerPageOptions: [10, 25, 50],
+      rowsPerPageOptions: [15, 30, 45],
       showFirstButton: false,
       showLastButton: false,
       size: 'small',


### PR DESCRIPTION
## Description

Tweaks subsystems that can be displayed to 15, 30 and 45 like the items in the tables on the systems page.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

