### PR TITLE
Resolve authenticated request immediately if not logged in #399

### DIFF
--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -45,11 +45,13 @@ imsApi.interceptors.response.use(
       : error.message;
 
     // Check if the token is invalid and needs refreshing
-    // only allow a request to be retried once
+    // only allow a request to be retried once. Don't retry if not logged
+    // in, it should not have been accessible
     if (
       error.response?.status === 403 &&
       errorMessage.includes('expired token') &&
-      !originalRequest._retried
+      !originalRequest._retried &&
+      localStorage.getItem('scigateway:token')
     ) {
       originalRequest._retried = true;
 


### PR DESCRIPTION
## Description

Resolves requests immediately if the user is not logged in and is trying to access a protected resource, rather than before which attempted to refresh the token. Also hides the error message when this occurs (as well as any 403 as it is assumed this should be handled by SciGateway like in DataGateway).

I also noticed that the status check was wrong, meaning the error message for a 500 error would not be used so I fixed that here.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #399
