### PR TITLE
Pin docker images to SHA

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -82,7 +82,7 @@ jobs:
           MONGO_INITDB_ROOT_PASSWORD: example
 
       ims-api:
-        image: harbor.stfc.ac.uk/inventory-management-system/ims-api:develop
+        image: ${{ secrets.HARBOR_URL }}/ims-api:develop
         ports:
           - 8000:8000
         env:
@@ -146,7 +146,7 @@ jobs:
       - name: Login to Harbor
         uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
-          registry: harbor.stfc.ac.uk/inventory-management-system
+          registry: ${{ secrets.HARBOR_URL }}
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
 
@@ -154,7 +154,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5.5.0
         with:
-          images: harbor.stfc.ac.uk/inventory-management-system/ims
+          images: ${{ secrets.HARBOR_URL }}/ims
 
       - name: Build and push Docker image to Harbor
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -82,7 +82,7 @@ jobs:
           MONGO_INITDB_ROOT_PASSWORD: example
 
       ims-api:
-        image: ${{ secrets.HARBOR_URL }}/ims-api:develop
+        image: harbor.stfc.ac.uk/inventory-management-system/ims-api:develop
         ports:
           - 8000:8000
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Specify a base image
-FROM node:20.11-alpine3.19
+FROM node:20.11.1-alpine3.19@sha256:c0a3badbd8a0a760de903e00cedbca94588e609299820557e72cba2a53dbaa2c
 
 # Set the working directory
 WORKDIR /inventory-management-system-run

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,7 +1,7 @@
 # Dockerfile to build and serve inventory management system
 
 # Build stage
-FROM node:20.11-alpine3.19 as builder
+FROM node:20.11.1-alpine3.19@sha256:c0a3badbd8a0a760de903e00cedbca94588e609299820557e72cba2a53dbaa2c as builder
 
 WORKDIR /inventory-management-system-build
 
@@ -30,7 +30,7 @@ RUN set -eux; \
     yarn build;
 
 # Run stage
-FROM httpd:2.4-alpine3.19
+FROM httpd:2.4.58-alpine3.19@sha256:5f3c87973b3e76601b2f4d8832d6075e272868815e4966d2e57823591f8da29f
 
 WORKDIR /usr/local/apache2/htdocs
 


### PR DESCRIPTION
## Description
This PR pins the base docker images in the Dockerfiles to commit SHAs so that Renovate (or Dependabot if Renovate doesn't work) can create PRs each time there is a change in the upstream base images that the base images are set to use as new SHAs are generated on every upstream change. Not sure if Renovate will also update the OS versions but if it doesn't then we will have to do the Alpine version updates manually for now.

Please note that I have pinned it to an older SHA to verify that Renovate (or Dependabot if Renovate doesn't work) will create a PR.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build