### PR TITLE
Modify vite config to output an lcov.info #473

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -128,6 +128,15 @@ export default defineConfig(({ mode }) => {
       globalSetup: './globalSetup.js',
       setupFiles: ['src/setupTests.ts'],
       coverage: {
+        reporter: [
+          // Default
+          'text',
+          'html',
+          'clover',
+          'json',
+          // Extra for VSCode extension
+          ['lcov', { outputFile: 'lcov.info', silent: true }],
+        ],
         exclude: [
           'public/*',
           'server/*',


### PR DESCRIPTION
## Description

Should fix vscode extensions not picking up coverage. I tried this with https://marketplace.visualstudio.com/items?itemName=markis.code-coverage.

Should make the same change to the vite branch of SciGateway if this works.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #473
