### PR TITLE
Hide move & copy to buttons on obsolete catalogue item dialogue #585

### DIFF
--- a/src/catalogue/items/__snapshots__/catalogueItemsTable.component.test.tsx.snap
+++ b/src/catalogue/items/__snapshots__/catalogueItemsTable.component.test.tsx.snap
@@ -320,7 +320,7 @@ exports[`Catalogue Items Table > renders the dense table correctly 1`] = `
                             aria-label="Filter by Name"
                             autocomplete="new-password"
                             class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-929hxt-MuiInputBase-input-MuiInput-input"
-                            id=":r1r2:"
+                            id=":r1su:"
                             placeholder="Filter by Name"
                             title="Filter by Name"
                             type="text"
@@ -887,7 +887,7 @@ exports[`Catalogue Items Table > renders the dense table correctly 1`] = `
                   class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary  css-1mmm5cp-MuiInputBase-root-MuiInput-root-MuiSelect-root"
                 >
                   <div
-                    aria-controls=":r1r4:"
+                    aria-controls=":r1t0:"
                     aria-expanded="false"
                     aria-haspopup="listbox"
                     aria-label="Rows per page"

--- a/src/catalogue/items/catalogueItemsTable.component.test.tsx
+++ b/src/catalogue/items/catalogueItemsTable.component.test.tsx
@@ -482,7 +482,7 @@ describe('Catalogue Items Table', () => {
     const rowToggleSelect = screen.getAllByLabelText('Toggle select row');
     await user.click(rowToggleSelect[1]);
 
-    expect(screen.getByRole('button', { name: 'Move to' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Move to' })).toBeInTheDocument();
     const moveToButton = screen.getByRole('button', { name: 'Move to' });
 
     await user.click(moveToButton);
@@ -503,7 +503,7 @@ describe('Catalogue Items Table', () => {
     const rowToggleSelect = screen.getAllByLabelText('Toggle select row');
     await user.click(rowToggleSelect[1]);
 
-    expect(screen.getByRole('button', { name: 'Copy to' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Copy to' })).toBeInTheDocument();
     const copyToButton = screen.getByRole('button', { name: 'Copy to' });
 
     await user.click(copyToButton);

--- a/src/catalogue/items/catalogueItemsTable.component.test.tsx
+++ b/src/catalogue/items/catalogueItemsTable.component.test.tsx
@@ -482,11 +482,7 @@ describe('Catalogue Items Table', () => {
     const rowToggleSelect = screen.getAllByLabelText('Toggle select row');
     await user.click(rowToggleSelect[1]);
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Move to' })
-      ).toBeInTheDocument();
-    });
+    expect(screen.getByRole('button', { name: 'Move to' })).toBeInTheDocument();
     const moveToButton = screen.getByRole('button', { name: 'Move to' });
 
     await user.click(moveToButton);
@@ -507,11 +503,7 @@ describe('Catalogue Items Table', () => {
     const rowToggleSelect = screen.getAllByLabelText('Toggle select row');
     await user.click(rowToggleSelect[1]);
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Copy to' })
-      ).toBeInTheDocument();
-    });
+    expect(screen.getByRole('button', { name: 'Copy to' })).toBeInTheDocument();
     const copyToButton = screen.getByRole('button', { name: 'Copy to' });
 
     await user.click(copyToButton);
@@ -521,6 +513,46 @@ describe('Catalogue Items Table', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
+  });
+
+  it('does not display move or copy buttons for move to requestOrigin', async () => {
+    props.requestOrigin = 'move to';
+
+    createView();
+
+    await waitFor(() => {
+      expect(screen.getByText('Energy Meters 26')).toBeInTheDocument();
+    });
+    const rowToggleSelect = screen.getAllByLabelText('Toggle select row');
+    await user.click(rowToggleSelect[1]);
+
+    expect(
+      screen.queryByRole('button', { name: 'Move to' })
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: 'Copy to' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not display move or copy buttons for obsolete requestOrigin', async () => {
+    props.requestOrigin = 'obsolete';
+
+    createView();
+
+    await waitFor(() => {
+      expect(screen.getByText('Energy Meters 26')).toBeInTheDocument();
+    });
+    const rowToggleSelect = screen.getAllByLabelText('Toggle select row');
+    await user.click(rowToggleSelect[1]);
+
+    expect(
+      screen.queryByRole('button', { name: 'Move to' })
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: 'Copy to' })
+    ).not.toBeInTheDocument();
   });
 
   it('navigates to the manufacturer url', async () => {

--- a/src/catalogue/items/catalogueItemsTable.component.tsx
+++ b/src/catalogue/items/catalogueItemsTable.component.tsx
@@ -789,35 +789,40 @@ const CatalogueItemsTable = (props: CatalogueItemsTableProps) => {
           >
             Add Catalogue Item
           </Button>
-          {selectedRowIds.length > 0 && (
-            <>
-              <MoveCatalogueItemsButton
-                selectedItems={selectedCatalogueItems}
-                onChangeSelectedItems={setRowSelection}
-                parentCategoryId={parentInfo.id}
-                parentInfo={parentInfo}
-              />
-              <CopyCatalogueItemsButton
-                selectedItems={selectedCatalogueItems}
-                onChangeSelectedItems={setRowSelection}
-                parentCategoryId={parentInfo.id}
-                parentInfo={parentInfo}
-              />
-            </>
-          )}
-          {requestOrigin === undefined && (
-            <Button
-              startIcon={<ClearIcon />}
-              sx={{ mx: 0.5 }}
-              variant="outlined"
-              disabled={preservedState.columnFilters.length === 0}
-              onClick={() => {
-                table.resetColumnFilters();
-              }}
-            >
-              Clear Filters
-            </Button>
-          )}
+          {
+            // Don't show for the move to and obsolete dialogues
+            requestOrigin === undefined && (
+              <>
+                {selectedRowIds.length > 0 && (
+                  <>
+                    <MoveCatalogueItemsButton
+                      selectedItems={selectedCatalogueItems}
+                      onChangeSelectedItems={setRowSelection}
+                      parentCategoryId={parentInfo.id}
+                      parentInfo={parentInfo}
+                    />
+                    <CopyCatalogueItemsButton
+                      selectedItems={selectedCatalogueItems}
+                      onChangeSelectedItems={setRowSelection}
+                      parentCategoryId={parentInfo.id}
+                      parentInfo={parentInfo}
+                    />
+                  </>
+                )}
+                <Button
+                  startIcon={<ClearIcon />}
+                  sx={{ mx: 0.5 }}
+                  variant="outlined"
+                  disabled={preservedState.columnFilters.length === 0}
+                  onClick={() => {
+                    table.resetColumnFilters();
+                  }}
+                >
+                  Clear Filters
+                </Button>
+              </>
+            )
+          }
         </Box>
       ),
     renderRowActionMenuItems: ({ closeMenu, row, table }) => {


### PR DESCRIPTION
## Description

See #585. Added two short unit tests to cover in the future although as part of that I noticed that we don't seem to need the `waitFor`'s on the move to and copy to buttons. Just as well as if we did these two new tests wouldn't make sense. (Have checked for missing act warning and haven't seen any test flakiness myself)

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #585
