### PR TITLE
Fix no loading indicator for CC no results #617

### DIFF
--- a/src/catalogue/catalogue.component.tsx
+++ b/src/catalogue/catalogue.component.tsx
@@ -350,7 +350,7 @@ function Catalogue() {
         </Grid>
       </Grid>
 
-      {catalogueCategoryDataLoading &&
+      {(catalogueCategoryDataLoading || !catalogueCategoryData) &&
         (!catalogueCategoryDetailLoading || !catalogueCategoryDetail) &&
         !parentInfo?.is_leaf && (
           <Box sx={{ width: '100%' }}>


### PR DESCRIPTION
## Description

See #617. This was caused by not waiting on all the data to be loaded as the catalogue categories data wouldn't start loading until after the parent has already been loaded.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #617
