### PR TITLE
Configure Renovate to update release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,22 @@
   "postUpdateOptions": ["yarnDedupeHighest"],
   "labels": ["dependencies"],
   "separateMinorPatch": true,
-  "cdnurl": {
-    "fileMatch": ["windowPortal\\.component\\.tsx$"]
-  }
+  "baseBranches": ["main", "develop", "v*"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "matchBaseBranches": ["main", "v*"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchBaseBranches": ["main", "v*"],
+      "enabled": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchBaseBranches": ["main", "v*"],
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
## Description

See #755. I hope this config enable updates on `main` and `v*` but only for dockerfiles or github-actions. Also removed cdnurl as it was from OG.

## Testing instructions

Can't really validate what it will do until merged. It passed `npx --yes --package renovate -- renovate-config-validator`. It is also  possible to run locally using `LOG_LEVEL=debug npx renovate --platform=local --repository-cache=reset > output.txt` but it doesn't take into account the branches (see https://docs.renovatebot.com/modules/platform/local/) so the best I could do is test it while deleting the branch matching to ensure it either detected an update or not based on the rest of the config.

- [ ] Review code
- [ ] Check Actions build

## Agile board tracking

Closes #755
