### PR TITLE
Add cypress folder to ignored coverage to stop codecov detecting

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -140,6 +140,7 @@ export default defineConfig(({ mode }) => {
         exclude: [
           'public/*',
           'server/*',
+          'cypress/*',
           // Leave handlers to show up unused code
           'src/mocks/browser.ts',
           'src/mocks/server.ts',


### PR DESCRIPTION
## Description

Found on #866. Cypress tests dont have any coverage reported so they should be ignored. Not sure why it wasn't present in https://github.com/ral-facilities/inventory-management-system/pull/542.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
