### PR TITLE
Prevent an item's delivered date being set in the future #1014

### DIFF
--- a/cypress/e2e/with_api/items/functions.ts
+++ b/cypress/e2e/with_api/items/functions.ts
@@ -273,7 +273,7 @@ export const editItem = () => {
     assetNumber: 'PY42343424',
     purchaseOrderNumber: '2334',
     warrantyEndDate: '17/02/2030',
-    deliveredDate: '19/03/2026',
+    deliveredDate: '19/03/2024',
     isDefective: 'No',
     usageStatus: 'Used',
     notes: 'tests',

--- a/cypress/e2e/with_mock_data/items.cy.ts
+++ b/cypress/e2e/with_mock_data/items.cy.ts
@@ -277,7 +277,7 @@ describe('Items', () => {
     cy.findByLabelText('Asset number').type('test13221');
     cy.findByLabelText('Purchase order number').type('test23');
     cy.findByLabelText('Warranty end date').type('12/02/2028');
-    cy.findByLabelText('Delivered date').type('12/02/2028');
+    cy.findByLabelText('Delivered date').type('12/02/2024');
     cy.findByLabelText('Is defective *').click();
     cy.findByRole('option', { name: 'Yes' }).click();
     cy.findByLabelText('Usage status *').click();
@@ -317,7 +317,7 @@ describe('Items', () => {
           warranty_end_date: '2028-02-12T00:00:00.000Z',
           asset_number: 'test13221',
           serial_number: 'test1234',
-          delivered_date: '2028-02-12T00:00:00.000Z',
+          delivered_date: '2024-02-12T00:00:00.000Z',
           notes: 'test',
           properties: [
             { id: '1', value: 1218 },
@@ -347,7 +347,10 @@ describe('Items', () => {
 
     cy.findByLabelText('Warranty end date').type('12/02/4000');
     cy.findByLabelText('Delivered date').type('12/02/4000');
-    cy.findAllByText('Date cannot be later than 1/1/2100.').should(
+    cy.findAllByText(
+      'Date cannot be later than',
+      {exact: false}
+    ).should(
       'have.length',
       2
     );
@@ -357,7 +360,10 @@ describe('Items', () => {
 
     cy.findByLabelText('Warranty end date').type('12/02/2000');
     cy.findByLabelText('Delivered date').type('12/02/2000');
-    cy.findByText('Date cannot be later than 1/1/2100.').should('not.exist');
+    cy.findByText(
+      'Date cannot be later than',
+      {exact: false}
+    ).should('not.exist');
     cy.findByText('Date format: dd/MM/yyyy').should('not.exist');
 
     cy.findByRole('button', { name: 'Next' }).click();
@@ -515,7 +521,7 @@ describe('Items', () => {
     cy.findByLabelText('Asset number').type('test13221');
     cy.findByLabelText('Purchase order number').type('test23');
     cy.findByLabelText('Warranty end date').type('12/02/2028');
-    cy.findByLabelText('Delivered date').type('12/02/2028');
+    cy.findByLabelText('Delivered date').type('12/02/2024');
     cy.findByLabelText('Is defective *').click();
     cy.findByRole('option', { name: 'Yes' }).click();
     cy.findByLabelText('Usage status *').click();
@@ -555,7 +561,7 @@ describe('Items', () => {
           usage_status_id: '3',
           warranty_end_date: '2028-02-12T23:00:00.000Z',
           asset_number: '75YWiLwy54test13221',
-          delivered_date: '2028-02-12T00:00:00.000Z',
+          delivered_date: '2024-02-12T00:00:00.000Z',
           notes: 'zolZDKKuvAoTFRUWeZNAtest',
           system_id: '65328f34a40ff5301575a4e3',
           properties: [

--- a/src/form.schemas.tsx
+++ b/src/form.schemas.tsx
@@ -519,7 +519,7 @@ export const PropertiesStepSchema = z.object({
   properties: z.array(z.discriminatedUnion('valueType', propertiesTypeList)),
 });
 
-// ------------------------------------ CATALOGUE ITEMS ------------------------------------
+// ------------------------------------ ITEMS ------------------------------------
 
 export const ItemDetailsStepSchema = (requestType: RequestType) => {
   return z.object({

--- a/src/form.schemas.tsx
+++ b/src/form.schemas.tsx
@@ -9,6 +9,7 @@ export type RequestType = 'post' | 'patch';
 
 export const DATE_PICKER_MIN_DATE = new Date('1900-01-01');
 export const DATE_PICKER_MAX_DATE = new Date('2100-01-01');
+export const DATE_TODAY = new Date();
 export const INVALID_DATE_FORMAT_MESSAGE = 'Date format: dd/MM/yyyy';
 
 interface BaseZodSchemaProps {
@@ -597,7 +598,7 @@ export const ItemDetailsStepSchema = (requestType: RequestType) => {
       }),
     delivered_date: OptionalOrNullableDateSchema({
       requestType: requestType,
-      maxDate: DATE_PICKER_MAX_DATE,
+      maxDate: DATE_TODAY,
       minDate: DATE_PICKER_MIN_DATE,
       dateFormatErrorMessage: INVALID_DATE_FORMAT_MESSAGE,
     }),

--- a/src/items/itemDialog.component.test.tsx
+++ b/src/items/itemDialog.component.test.tsx
@@ -421,7 +421,7 @@ describe('ItemDialog', () => {
         purchaseOrderNumber: 'test21',
         notes: 'test',
         warrantyEndDate: '17/02/2035',
-        deliveredDate: '23/09/2045',
+        deliveredDate: '23/09/2024',
         isDefective: 'Y{arrowdown}{enter}',
         usageStatus: 'U{arrowdown}{enter}',
       });
@@ -448,7 +448,7 @@ describe('ItemDialog', () => {
       expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items', {
         asset_number: 'test43',
         catalogue_item_id: '1',
-        delivered_date: '2045-09-23T00:00:00.000Z',
+        delivered_date: '2024-09-23T00:00:00.000Z',
         is_defective: true,
         notes: 'test',
         properties: [
@@ -622,7 +622,7 @@ describe('ItemDialog', () => {
         purchaseOrderNumber: 'test21',
         notes: 'test',
         warrantyEndDate: '17/02/2035',
-        deliveredDate: '23/09/2045',
+        deliveredDate: '23/09/2024',
         isDefective: 'Y{arrowdown}{enter}',
         usageStatus: 'U{arrowdown}{enter}',
       });
@@ -649,7 +649,7 @@ describe('ItemDialog', () => {
       expect(axiosPostSpy).toHaveBeenCalledWith('/v1/items', {
         asset_number: 'test43',
         catalogue_item_id: '1',
-        delivered_date: '2045-09-23T00:00:00.000Z',
+        delivered_date: '2024-09-23T00:00:00.000Z',
         is_defective: true,
         notes: 'test',
         properties: [
@@ -702,7 +702,7 @@ describe('ItemDialog', () => {
         purchaseOrderNumber: 'test21',
         notes: 'test',
         warrantyEndDate: '17/02/2035',
-        deliveredDate: '23/09/2045',
+        deliveredDate: '23/09/2024',
         isDefective: 'Y{arrowdown}{enter}',
         usageStatus: 'U{arrowdown}{enter}',
       });
@@ -770,7 +770,8 @@ describe('ItemDialog', () => {
       });
 
       const validDateMaxHelperText = await screen.findAllByText(
-        'Date cannot be later than 1/1/2100.'
+        'Date cannot be later than',
+        {exact: false}
       );
       expect(validDateMaxHelperText.length).toEqual(2);
 
@@ -782,7 +783,10 @@ describe('ItemDialog', () => {
       });
 
       expect(
-        screen.queryByText('Date cannot be later than 1/1/2100.')
+        screen.queryByText(
+          'Date cannot be later than',
+          {exact: false}
+        )
       ).not.toBeInTheDocument();
       expect(
         screen.queryByText(
@@ -983,7 +987,7 @@ describe('ItemDialog', () => {
         purchaseOrderNumber: 'test21',
         notes: 'test',
         warrantyEndDate: '17/02/2035',
-        deliveredDate: '23/09/2045',
+        deliveredDate: '23/09/2024',
         isDefective: 'Y{arrowdown}{enter}',
         usageStatus: 'U{enter}',
       });
@@ -1014,7 +1018,7 @@ describe('ItemDialog', () => {
 
       expect(axiosPatchSpy).toHaveBeenCalledWith('/v1/items/G463gOIA', {
         asset_number: 'test43',
-        delivered_date: '2045-09-23T23:00:00.000Z',
+        delivered_date: '2024-09-23T23:00:00.000Z',
         is_defective: true,
         notes: 'test',
         properties: [

--- a/src/items/itemDialog.component.tsx
+++ b/src/items/itemDialog.component.tsx
@@ -48,6 +48,7 @@ import {
 import {
   DATE_PICKER_MAX_DATE,
   DATE_PICKER_MIN_DATE,
+  DATE_TODAY,
   INVALID_DATE_FORMAT_MESSAGE,
   ItemDetailsStepSchema,
   PropertiesStepSchema,
@@ -702,7 +703,7 @@ function ItemDialog(props: ItemDialogProps) {
                         ? new Date(field.value)
                         : null
                     }
-                    maxDate={DATE_PICKER_MAX_DATE}
+                    maxDate={DATE_TODAY}
                     minDate={DATE_PICKER_MIN_DATE}
                     onChange={(value) => {
                       if (value && !isNaN(value.getTime())) {
@@ -726,7 +727,7 @@ function ItemDialog(props: ItemDialogProps) {
                       const errorMessage = dateErrorMessageHandler({
                         error,
                         minDate: DATE_PICKER_MIN_DATE,
-                        maxDate: DATE_PICKER_MAX_DATE,
+                        maxDate: DATE_TODAY,
                       });
                       if (errorMessage !== '') {
                         setErrorDetailsStep('delivered_date', {


### PR DESCRIPTION
## Description

Prevent an item's delivered date being set to a date in the future.
By setting maxDate as DATE_TODAY instead of DATE_PICKER_MAX_DATE.
Also fixes an incorrect comment (see #1052)


## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking

Resolves #1014 
Resolves #1052 
