### PR TITLE
Prevent negative numbers being set where they shouldn't be in Catalogue Items #970

### DIFF
--- a/cypress/e2e/with_mock_data/catalogueItems.cy.ts
+++ b/cypress/e2e/with_mock_data/catalogueItems.cy.ts
@@ -325,6 +325,7 @@ describe('Catalogue Items', () => {
         cy.findByRole('button', { name: 'Next' }).should('be.disabled');
 
         // details - negative number input validation test
+        cy.findByLabelText('Drawing link').clear();
         cy.findByLabelText('Cost (£) *').clear();
         cy.findByLabelText('Cost (£) *').type('-10')
         cy.findByLabelText('Cost to rework (£)').clear();
@@ -346,7 +347,6 @@ describe('Catalogue Items', () => {
         cy.findByLabelText('Time to replace (days) *').type('14');
         cy.findByLabelText('Cost to rework (£)').clear();
         cy.findByLabelText('Time to rework (days)').clear();
-        cy.findByLabelText('Drawing link').clear();
         cy.findByLabelText('Drawing link').type('https://test.co.uk');
 
         cy.findByRole('button', { name: 'Next' }).click();

--- a/cypress/e2e/with_mock_data/catalogueItems.cy.ts
+++ b/cypress/e2e/with_mock_data/catalogueItems.cy.ts
@@ -306,8 +306,7 @@ describe('Catalogue Items', () => {
           'Please enter a valid value as this field is mandatory.'
         ).should('have.length', 0);
 
-        // value error from number field
-
+        // details - invalid number input test
         cy.findByRole('button', { name: 'Back' }).click();
 
         cy.findByLabelText('Cost (£) *').clear();
@@ -324,15 +323,35 @@ describe('Catalogue Items', () => {
           'Please enter a valid Drawing link. Only "http://" and "https://" links with typical top-level domain are accepted.'
         ).should('exist');
         cy.findByRole('button', { name: 'Next' }).should('be.disabled');
+
+        // details - negative number input validation test
+        cy.findByLabelText('Cost (£) *').clear();
+        cy.findByLabelText('Cost (£) *').type('-10')
+        cy.findByLabelText('Cost to rework (£)').clear();
+        cy.findByLabelText('Cost to rework (£)').type('-10')
+        cy.findByLabelText('Time to replace (days) *').clear();
+        cy.findByLabelText('Time to replace (days) *').type('-10')
+        cy.findByLabelText('Time to rework (days)').clear();
+        cy.findByLabelText('Time to rework (days)').type('-10')
+
+        cy.findAllByText('Number must be greater than or equal to 0').should(
+          'have.length',
+          4
+        )
+        cy.findByRole('button', { name: 'Next' }).should('be.disabled');
+
         cy.findByLabelText('Cost (£) *').clear();
         cy.findByLabelText('Cost (£) *').type('5000');
         cy.findByLabelText('Time to replace (days) *').clear();
         cy.findByLabelText('Time to replace (days) *').type('14');
+        cy.findByLabelText('Cost to rework (£)').clear();
+        cy.findByLabelText('Time to rework (days)').clear();
         cy.findByLabelText('Drawing link').clear();
         cy.findByLabelText('Drawing link').type('https://test.co.uk');
 
         cy.findByRole('button', { name: 'Next' }).click();
 
+        // properties - invalid number input test
         cy.findByLabelText('Resolution (megapixels) *').clear();
         cy.findByLabelText('Resolution (megapixels) *').type('dsfs');
         cy.findByLabelText('Frame Rate (fps)').type('fdsfsd');

--- a/src/catalogue/items/catalogueItemsDialog.component.test.tsx
+++ b/src/catalogue/items/catalogueItemsDialog.component.test.tsx
@@ -587,6 +587,50 @@ describe('Catalogue Items Dialog', () => {
     );
   }, 10000);
 
+  it('display error message when a value is invalid because it is negative', async () => {
+    props = {
+      ...props,
+      parentInfo: getCatalogueCategoryById('4'),
+    };
+
+    createView();
+
+    await modifyValues({
+      costGbp: '-5',
+      costToReworkGbp: '-5',
+      daysToReplace: '-5',
+      daysToRework: '-5',
+      description: '',
+      drawingLink: 'https://example.com',
+      drawingNumber: 'mk4324',
+      itemModelNumber: 'mk4324',
+      name: 'test',
+      manufacturer: 'Man{arrowdown}{enter}',
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    // there should be 4 instances of the negative number error message
+    const NegativeNumberErrorText = screen.getAllByText(
+      'Number must be greater than or equal to 0'
+    );
+
+    expect(NegativeNumberErrorText.length).toBe(4);
+    expect(NegativeNumberErrorText[0]).toHaveTextContent(
+      'Number must be greater than or equal to 0'
+    );
+
+    await modifyValues({
+      costGbp: '5',
+      costToReworkGbp: '5',
+      daysToReplace: '5',
+      daysToRework: '5',
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await user.click(screen.getByRole('button', { name: 'Finish' }));
+  }, 10000);
+
   it('displays warning message when an unknown error occurs', async () => {
     props = {
       ...props,

--- a/src/catalogue/items/catalogueItemsDialog.component.test.tsx
+++ b/src/catalogue/items/catalogueItemsDialog.component.test.tsx
@@ -610,7 +610,6 @@ describe('Catalogue Items Dialog', () => {
 
     await user.click(screen.getByRole('button', { name: 'Next' }));
 
-    // there should be 4 instances of the negative number error message
     const NegativeNumberErrorText = screen.getAllByText(
       'Number must be greater than or equal to 0'
     );

--- a/src/form.schemas.tsx
+++ b/src/form.schemas.tsx
@@ -488,19 +488,23 @@ export const CatalogueItemDetailsStepSchema = (requestType: RequestType) => {
     cost_gbp: MandatoryNumberSchema({
       requiredErrorMessage: 'Please enter a cost.',
       invalidTypeErrorMessage: 'Please enter a valid number.',
+      min: 0
     }),
     cost_to_rework_gbp: OptionalOrNullableNumberSchema({
       requestType,
       invalidTypeErrorMessage: 'Please enter a valid number.',
+      min: 0
     }),
     days_to_replace: MandatoryNumberSchema({
       requiredErrorMessage:
         'Please enter how many days it would take to replace.',
       invalidTypeErrorMessage: 'Please enter a valid number.',
+      min: 0
     }),
     days_to_rework: OptionalOrNullableNumberSchema({
       requestType,
       invalidTypeErrorMessage: 'Please enter a valid number.',
+      min: 0
     }),
     description: OptionalOrNullableStringSchema({ requestType }),
     drawing_number: OptionalOrNullableStringSchema({ requestType }),


### PR DESCRIPTION
## Description

To provide negative number validation, set min:0 for cost and days variables.
Adds a unit test, and additional testing to cypress e2e with mock data test.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking

Resolves #970 
