### PR TITLE
Add negative number validation to Expected Lifetime

### DIFF
--- a/cypress/e2e/with_mock_data/catalogueItems.cy.ts
+++ b/cypress/e2e/with_mock_data/catalogueItems.cy.ts
@@ -334,18 +334,20 @@ describe('Catalogue Items', () => {
         // details - negative number input validation test
         cy.findByLabelText('Drawing link').clear();
         cy.findByLabelText('Cost (£) *').clear();
-        cy.findByLabelText('Cost (£) *').type('-10')
+        cy.findByLabelText('Cost (£) *').type('-10');
         cy.findByLabelText('Cost to rework (£)').clear();
-        cy.findByLabelText('Cost to rework (£)').type('-10')
+        cy.findByLabelText('Cost to rework (£)').type('-10');
+        cy.findByLabelText('Expected Lifetime (days)').clear();
+        cy.findByLabelText('Expected Lifetime (days)').type('-10');
         cy.findByLabelText('Time to replace (days) *').clear();
-        cy.findByLabelText('Time to replace (days) *').type('-10')
+        cy.findByLabelText('Time to replace (days) *').type('-10');
         cy.findByLabelText('Time to rework (days)').clear();
-        cy.findByLabelText('Time to rework (days)').type('-10')
+        cy.findByLabelText('Time to rework (days)').type('-10');
 
         cy.findAllByText('Number must be greater than or equal to 0').should(
           'have.length',
-          4
-        )
+          5
+        );
         cy.findByRole('button', { name: 'Next' }).should('be.disabled');
 
         cy.findByLabelText('Cost (£) *').clear();

--- a/src/catalogue/items/catalogueItemsDialog.component.test.tsx
+++ b/src/catalogue/items/catalogueItemsDialog.component.test.tsx
@@ -618,6 +618,7 @@ describe('Catalogue Items Dialog', () => {
       description: '',
       drawingLink: 'https://example.com',
       drawingNumber: 'mk4324',
+      expectedLifetimeDays: '-5',
       itemModelNumber: 'mk4324',
       name: 'test',
       manufacturer: 'Man{arrowdown}{enter}',
@@ -629,7 +630,7 @@ describe('Catalogue Items Dialog', () => {
       'Number must be greater than or equal to 0'
     );
 
-    expect(NegativeNumberErrorText.length).toBe(4);
+    expect(NegativeNumberErrorText.length).toBe(5);
     expect(NegativeNumberErrorText[0]).toHaveTextContent(
       'Number must be greater than or equal to 0'
     );
@@ -639,6 +640,7 @@ describe('Catalogue Items Dialog', () => {
       costToReworkGbp: '5',
       daysToReplace: '5',
       daysToRework: '5',
+      expectedLifetimeDays: '5',
     });
 
     await user.click(screen.getByRole('button', { name: 'Next' }));

--- a/src/form.schemas.tsx
+++ b/src/form.schemas.tsx
@@ -489,27 +489,28 @@ export const CatalogueItemDetailsStepSchema = (requestType: RequestType) => {
     cost_gbp: MandatoryNumberSchema({
       requiredErrorMessage: 'Please enter a cost.',
       invalidTypeErrorMessage: 'Please enter a valid number.',
-      min: 0
+      min: 0,
     }),
     cost_to_rework_gbp: OptionalOrNullableNumberSchema({
       requestType,
       invalidTypeErrorMessage: 'Please enter a valid number.',
-      min: 0
+      min: 0,
     }),
     days_to_replace: MandatoryNumberSchema({
       requiredErrorMessage:
         'Please enter how many days it would take to replace.',
       invalidTypeErrorMessage: 'Please enter a valid number.',
-      min: 0
+      min: 0,
     }),
     days_to_rework: OptionalOrNullableNumberSchema({
       requestType,
       invalidTypeErrorMessage: 'Please enter a valid number.',
-      min: 0
+      min: 0,
     }),
     expected_lifetime_days: OptionalOrNullableNumberSchema({
       requestType,
       invalidTypeErrorMessage: 'Please enter a valid number.',
+      min: 0,
     }),
     description: OptionalOrNullableStringSchema({ requestType }),
     drawing_number: OptionalOrNullableStringSchema({ requestType }),


### PR DESCRIPTION


## Description

Add negative number validation for expected lifetime field in catalogue items dialog.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

