### PR TITLE
Remove limit for parallel images upload

### DIFF
--- a/src/common/images/uploadImagesDialog.component.tsx
+++ b/src/common/images/uploadImagesDialog.component.tsx
@@ -48,10 +48,6 @@ const UploadImagesDialog = (props: UploadImagesDialogProps) => {
         endpoint: `${url}/images`,
         method: 'POST',
         fieldName: 'upload_file',
-        limit: 1, // Limit uploads to one file at a time
-        // Reason 1: To avoid overloading the memory of the object-store API.
-        // Reason 2: To prevent multiple simultaneous uploads from triggering
-        // the token refresh process multiple times, which could lead to race conditions.
         async onBeforeRequest(xhr) {
           uppyOnBeforeRequest(xhr);
         },


### PR DESCRIPTION
## Description

Remove limit for parallel images upload. This has been fix in the object store api   
## Testing instructions


- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}


