### PR TITLE
Remove spacing around the equals for OS_API_URL #1288

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -63,7 +63,7 @@ RUN set -eux; \
 USER www-data
 
 ENV IMS_API_URL="/inventory-management-system-api"
-ENV OS_API_URL = "/object-storage-api"
+ENV OS_API_URL="/object-storage-api"
 ENV PLUGIN_HOST="/inventory-management-system"
 
 COPY docker/docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
## Description

The space around the equal is not the correct syntax and causes in when just to build for the full ims docker stack

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

