### PR TITLE
Patch Uppy AwsS3 to not expect the ETag #1292

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,4 @@ README.md
 .yarn/*
 !.yarn/releases
 !.yarn/plugins
+!.yarn/patches

--- a/.yarn/patches/@uppy-aws-s3-npm-4.1.3-4c4ba3e640.patch
+++ b/.yarn/patches/@uppy-aws-s3-npm-4.1.3-4c4ba3e640.patch
@@ -1,0 +1,46 @@
+diff --git a/lib/index.js b/lib/index.js
+index 24921be0f280435c159a1f08e1a172e67f6e4147..8b43fd5a18cfb3f6b46db02813283293724bb158 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -495,23 +495,25 @@ export default class AwsS3Multipart extends BasePlugin {
+           const value = parts.join(': ');
+           headersMap[header] = value;
+         }
+-        const {
+-          etag,
+-          location
+-        } = headersMap;
++        // const {
++        //   etag,
++        //   location
++        // } = headersMap;
+ 
+-        // More info bucket settings when this is not present:
+-        // https://github.com/transloadit/uppy/issues/5388#issuecomment-2464885562
+-        if (method.toUpperCase() === 'POST' && location == null) {
+-          // Not being able to read the Location header is not a fatal error.
+-          // eslint-disable-next-line no-console
+-          console.error('@uppy/aws-s3: Could not read the Location header. This likely means CORS is not configured correctly on the S3 Bucket. See https://uppy.io/docs/aws-s3/#setting-up-your-s3-bucket');
+-        }
+-        if (etag == null) {
+-          // eslint-disable-next-line no-console
+-          console.error('@uppy/aws-s3: Could not read the ETag header. This likely means CORS is not configured correctly on the S3 Bucket. See https://uppy.io/docs/aws-s3/#setting-up-your-s3-bucket');
+-          return;
+-        }
++        const etag = '';
++
++        // // More info bucket settings when this is not present:
++        // // https://github.com/transloadit/uppy/issues/5388#issuecomment-2464885562
++        // if (method.toUpperCase() === 'POST' && location == null) {
++        //   // Not being able to read the Location header is not a fatal error.
++        //   // eslint-disable-next-line no-console
++        //   console.error('@uppy/aws-s3: Could not read the Location header. This likely means CORS is not configured correctly on the S3 Bucket. See https://uppy.io/docs/aws-s3/#setting-up-your-s3-bucket');
++        // }
++        // if (etag == null) {
++        //   // eslint-disable-next-line no-console
++        //   console.error('@uppy/aws-s3: Could not read the ETag header. This likely means CORS is not configured correctly on the S3 Bucket. See https://uppy.io/docs/aws-s3/#setting-up-your-s3-bucket');
++        //   return;
++        // }
+         onComplete == null || onComplete(etag);
+         resolve({
+           ...headersMap,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@uppy/aws-s3": "^4.1.0",
+    "@uppy/aws-s3": "patch:@uppy/aws-s3@npm%3A4.1.3#~/.yarn/patches/@uppy-aws-s3-npm-4.1.3-4c4ba3e640.patch",
     "@uppy/core": "^4.2.2",
     "@uppy/dashboard": "^4.1.0",
     "@uppy/drag-drop": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2265,7 +2265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uppy/aws-s3@npm:^4.1.0":
+"@uppy/aws-s3@npm:4.1.3":
   version: 4.1.3
   resolution: "@uppy/aws-s3@npm:4.1.3"
   dependencies:
@@ -2274,6 +2274,18 @@ __metadata:
   peerDependencies:
     "@uppy/core": ^4.3.0
   checksum: 10c0/08607d19474712f912bc5a8a5f488e1b1df32bbdaa82846d75c4dc7cd47f008171b8dbdf165710b72311937586d80b2dd0b8ab73ce34f0a5b690114c32aae1b0
+  languageName: node
+  linkType: hard
+
+"@uppy/aws-s3@patch:@uppy/aws-s3@npm%3A4.1.3#~/.yarn/patches/@uppy-aws-s3-npm-4.1.3-4c4ba3e640.patch":
+  version: 4.1.3
+  resolution: "@uppy/aws-s3@patch:@uppy/aws-s3@npm%3A4.1.3#~/.yarn/patches/@uppy-aws-s3-npm-4.1.3-4c4ba3e640.patch::version=4.1.3&hash=c9e936"
+  dependencies:
+    "@uppy/companion-client": "npm:^4.2.0"
+    "@uppy/utils": "npm:^6.0.5"
+  peerDependencies:
+    "@uppy/core": ^4.3.0
+  checksum: 10c0/9607e38d77fca0ca5f7e80474b8d854c717d6fee6e343d62c8a77d245569a4335e9df3e3bbe8ba885a475c9e18d81105206477b34051ef81c3ed84483546389e
   languageName: node
   linkType: hard
 
@@ -5521,7 +5533,7 @@ __metadata:
     "@types/react": "npm:^18.3.3"
     "@types/react-dom": "npm:^18.3.0"
     "@types/react-router-dom": "npm:5.3.3"
-    "@uppy/aws-s3": "npm:^4.1.0"
+    "@uppy/aws-s3": "patch:@uppy/aws-s3@npm%3A4.1.3#~/.yarn/patches/@uppy-aws-s3-npm-4.1.3-4c4ba3e640.patch"
     "@uppy/core": "npm:^4.2.2"
     "@uppy/dashboard": "npm:^4.1.0"
     "@uppy/drag-drop": "npm:^4.0.2"


### PR DESCRIPTION
## Description

Set the ETag value to empty string and remove the warnings. This had to be doe in the index.js for it to work (not the tsx in the src).  

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage


This can be tested by using the mock data. To do this you would need to remove the ETag from post response(''/object-storage'')

## Agile board tracking

closes #1292
