### PR TITLE
Add upload attachment button to attachments table #1308

### DIFF
--- a/cypress/e2e/with_mock_data/items.cy.ts
+++ b/cypress/e2e/with_mock_data/items.cy.ts
@@ -473,6 +473,47 @@ describe('Items', () => {
       cy.clearMocks();
     });
 
+    it('opens and closes the upload attachments dialog from both the actions menu and the table button', () => {
+      cy.findByText('5YUQDDjKpz2z').click();
+      cy.findByText(
+        'High-resolution cameras for beam characterization. 1'
+      ).should('exist');
+
+      cy.findByRole('button', {
+        name: 'items landing page actions menu',
+      }).click();
+      cy.findByText('Upload Attachments').click();
+
+      cy.findAllByText('Files cannot be larger than', { exact: false }).should(
+        'exist'
+      );
+
+      cy.findByRole('button', {
+        name: 'Close Modal',
+      }).click();
+
+      cy.findByText(
+        'High-resolution cameras for beam characterization. 1'
+      ).should('exist');
+
+      cy.findByText('Attachments').click();
+      cy.findByRole('button', {
+        name: 'Upload Attachments',
+      }).click();
+
+      cy.findAllByText('Files cannot be larger than', { exact: false }).should(
+        'exist'
+      );
+
+      cy.findByRole('button', {
+        name: 'Close Modal',
+      }).click();
+
+      cy.findByText(
+        'High-resolution cameras for beam characterization. 1'
+      ).should('exist');
+    });
+
     it('uploads attachment', () => {
       cy.findByText('5YUQDDjKpz2z').click();
       cy.findByText(

--- a/src/common/attachments/__snapshots__/attachmentsTable.component.test.tsx.snap
+++ b/src/common/attachments/__snapshots__/attachmentsTable.component.test.tsx.snap
@@ -26,6 +26,31 @@ exports[`Attachments Table > renders no results page correctly 1`] = `
             class="MuiBox-root css-k008qs"
           >
             <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-1owl11-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  data-testid="AddIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                  />
+                </svg>
+              </span>
+              Upload Attachments
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+            <button
               class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-1owl11-MuiButtonBase-root-MuiButton-root"
               disabled=""
               tabindex="-1"
@@ -1658,6 +1683,31 @@ exports[`Attachments Table > renders table correctly 1`] = `
           <div
             class="MuiBox-root css-k008qs"
           >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-1owl11-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  data-testid="AddIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                  />
+                </svg>
+              </span>
+              Upload Attachments
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
             <button
               class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-1owl11-MuiButtonBase-root-MuiButton-root"
               disabled=""

--- a/src/common/attachments/attachmentsTable.component.test.tsx
+++ b/src/common/attachments/attachmentsTable.component.test.tsx
@@ -86,6 +86,27 @@ describe('Attachments Table', () => {
     expect(router.state.location.search).toBe('');
   });
 
+  it('opens the upload attachments dialog and closes it correctly', async () => {
+    createView();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('laser-calibration.txt').length).toEqual(3);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Upload Attachments' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Drop files here or')).toBeInTheDocument();
+    });
+
+    const closeButton = screen.getByRole('button', { name: 'Close Modal' });
+    await user.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Drop files here or')).not.toBeInTheDocument();
+    });
+  });
+
   it('sets the table filters and clears the table filters', async () => {
     createView();
 
@@ -196,8 +217,8 @@ describe('Attachments Table', () => {
 
     expect(screen.getByText('Delete Attachment')).toBeInTheDocument();
 
-    const closeButton = screen.getByRole('button', { name: 'Cancel' });
-    await user.click(closeButton);
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await user.click(cancelButton);
 
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();

--- a/src/common/attachments/attachmentsTable.component.tsx
+++ b/src/common/attachments/attachmentsTable.component.tsx
@@ -1,3 +1,4 @@
+import AddIcon from '@mui/icons-material/Add';
 import ClearIcon from '@mui/icons-material/Clear';
 import DeleteIcon from '@mui/icons-material/Delete'
 import DownloadIcon from '@mui/icons-material/Download';
@@ -23,6 +24,7 @@ import { useGetAttachments, usePatchAttachment } from '../../api/attachments';
 import DeleteAttachmentDialog from './deleteAttachmentDialog.component';
 import DownloadFileDialog from '../downloadFileDialog.component';
 import EditFileDialog from '../editFileDialog.component';
+import UploadAttachmentsDialog from './uploadAttachmentsDialog.component';
 import {
   COLUMN_FILTER_FUNCTIONS,
   COLUMN_FILTER_MODE_OPTIONS,
@@ -220,6 +222,16 @@ function AttachmentsTable(props: AttachmentTableProps) {
     // Functions
     ...onPreservedStatesChange,
 
+    renderCreateRowDialogContent: ({ table, row }) => (
+      <UploadAttachmentsDialog
+        open={true}
+        onClose={() => {
+          table.setCreatingRow(null);
+        }}
+        entityId={row.original.entity_id}
+      />
+    ),
+
     renderEditRowDialogContent: ({ table, row }) => (
       <EditFileDialog
         open={true}
@@ -232,6 +244,16 @@ function AttachmentsTable(props: AttachmentTableProps) {
 
     renderTopToolbarCustomActions: ({ table }) => (
       <Box sx={{ display: 'flex' }}>
+        <Button
+          startIcon={<AddIcon />}
+          sx={{ mx: '4px' }}
+          variant="outlined"
+          onClick={() => {
+            table.setCreatingRow(true);
+          }}
+        >
+          Upload Attachments
+        </Button>
         <Button
           startIcon={<ClearIcon />}
           sx={{ mx: '4px' }}

--- a/src/common/attachments/attachmentsTable.component.tsx
+++ b/src/common/attachments/attachmentsTable.component.tsx
@@ -39,6 +39,7 @@ import {
   mrtTheme,
 } from '../../utils';
 import { usePreservedTableState } from '../preservedTableState.component';
+import { StyledUppyBox } from '../uppy.utils';
 
 export interface AttachmentTableProps {
   entityId: string;
@@ -223,13 +224,15 @@ function AttachmentsTable(props: AttachmentTableProps) {
     ...onPreservedStatesChange,
 
     renderCreateRowDialogContent: ({ table }) => (
-      <UploadAttachmentsDialog
-        open={true}
-        onClose={() => {
-          table.setCreatingRow(null);
-        }}
-        entityId={entityId}
-      />
+      <StyledUppyBox>
+        <UploadAttachmentsDialog
+          open={true}
+          onClose={() => {
+            table.setCreatingRow(null);
+          }}
+          entityId={entityId}
+        />
+      </StyledUppyBox>
     ),
 
     renderEditRowDialogContent: ({ table, row }) => (

--- a/src/common/attachments/attachmentsTable.component.tsx
+++ b/src/common/attachments/attachmentsTable.component.tsx
@@ -222,13 +222,13 @@ function AttachmentsTable(props: AttachmentTableProps) {
     // Functions
     ...onPreservedStatesChange,
 
-    renderCreateRowDialogContent: ({ table, row }) => (
+    renderCreateRowDialogContent: ({ table }) => (
       <UploadAttachmentsDialog
         open={true}
         onClose={() => {
           table.setCreatingRow(null);
         }}
-        entityId={row.original.entity_id}
+        entityId={entityId}
       />
     ),
 

--- a/src/manufacturer/manufacturerTable.component.test.tsx
+++ b/src/manufacturer/manufacturerTable.component.test.tsx
@@ -62,8 +62,8 @@ describe('Manufacturer Table', () => {
 
     expect(screen.getByText('Delete Manufacturer')).toBeInTheDocument();
 
-    const closeButton = screen.getByRole('button', { name: 'Cancel' });
-    await user.click(closeButton);
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await user.click(cancelButton);
 
     await waitFor(() => {
       expect(screen.queryByText('Delete Manufacturer')).not.toBeInTheDocument();
@@ -103,8 +103,8 @@ describe('Manufacturer Table', () => {
 
     await user.click(screen.getByRole('button', { name: 'Add Manufacturer' }));
 
-    const closeButton = screen.getByRole('button', { name: 'Cancel' });
-    await user.click(closeButton);
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await user.click(cancelButton);
   });
 
   it('sets the table filters and clears the table filters', async () => {


### PR DESCRIPTION
## Description
- Add upload attachment button into attachments table, and add unit test for it
- Add cypress test for opening and closing upload attachments dialog - tests the dialog can be opened and closed when accessed via both the actions menu and the table button

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking

Resolves #1308
