### PR TITLE
Fix incorrect local setup instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For development purposes, use `yarn preview:build:dev` to build in watch mode so
    ```
 4. Start the website
    ```bash
-   yarn inventory-management-system
+   yarn dev
    ```
 
 ### End-to-End Testing (Locally)


### PR DESCRIPTION
## Description

Found a reminder to do this in a document I made at the start of the rotation 😆

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

