### PR TITLE
Only push docker images when manually requested #1326

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,6 +1,12 @@
 name: CI Build
 
 on:
+  workflow_dispatch:
+    inputs:
+      push-docker-image-to-harbor:
+        description: 'Push Docker Image to Harbor'
+        type: boolean
+        default: false
   pull_request:
   push:
     branches:
@@ -187,6 +193,8 @@ jobs:
     needs: [lint-and-unit-test, e2e-tests, e2e-tests-api]
     name: Docker
     runs-on: ubuntu-latest
+    env:
+      PUSH_DOCKER_IMAGE_TO_HARBOR: ${{ inputs.push-docker-image-to-harbor != null && inputs.push-docker-image-to-harbor || 'false' }}
     steps:
       - name: Check out repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -204,11 +212,11 @@ jobs:
         with:
           images: ${{ secrets.HARBOR_URL }}/ims
 
-      - name: Build and push Docker image to Harbor
+      - name: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
         uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
         with:
           context: .
           file: ./Dockerfile.prod
-          push: true
+          push: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description

Replicates Viktor's changes from scigateway-auth and object-storage-api to prevent us from pushing images each time the CI runs, and instead only when manually requested.

It appears `workflow_dispatch` was not in the CI action before now, unlike on the backend, so I cannot execute this as a test, it has to be merged to allow you to manually run it instead. However see the similar run here https://github.com/ral-facilities/inventory-management-system-api/actions/runs/14401560315/job/40388375982.

E.g.
https://github.com/ral-facilities/inventory-management-system-api/actions/workflows/.ci.yml
![image](https://github.com/user-attachments/assets/c887d067-4ba5-4210-90bb-738c51d62c98)


## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build

## Agile board tracking

Closes #1326
