### PR TITLE
fix: prevent image deletion when file is removed from upload dialog

### DIFF
--- a/src/common/attachments/uploadAttachmentsDialog.component.tsx
+++ b/src/common/attachments/uploadAttachmentsDialog.component.tsx
@@ -33,13 +33,12 @@ const UploadAttachmentsDialog = (props: UploadAttachmentsDialogProps) => {
 
   const queryClient = useQueryClient();
 
-  const { attachmentAllowedFileExtensions, maxAttachmentSizeBytes } = React.useContext(
-    InventoryManagementSystemSettingsContext
-  );
+  const { attachmentAllowedFileExtensions, maxAttachmentSizeBytes } =
+    React.useContext(InventoryManagementSystemSettingsContext);
 
   // Note: File systems use a factor of 1024 for GB, MB and KB instead of 1000,
   // so here the former is expected despite them really being GiB, MiB and KiB.
-  const maxAttachmentSizeMB = maxAttachmentSizeBytes / (1024 ** 2)
+  const maxAttachmentSizeMB = maxAttachmentSizeBytes / 1024 ** 2;
 
   const { mutateAsync: postAttachmentMetadata } = usePostAttachmentMetadata();
 
@@ -102,10 +101,14 @@ const UploadAttachmentsDialog = (props: UploadAttachmentsDialogProps) => {
       const id = fileMetadataMap[fileId];
 
       if (id) {
-        if (deleteMetadata && !deletedFileIds.current.has(fileId)) {
+        if (
+          deleteMetadata &&
+          !deletedFileIds.current.has(fileId) &&
+          file?.progress.uploadComplete === false
+        ) {
           deletedFileIds.current.add(fileId);
           await deleteAttachment(id).catch((error: AxiosError) => {
-            handleIMS_APIError(error);
+            handleIMS_APIError(error, false);
           });
         }
 


### PR DESCRIPTION
## Description
Ensure that removing a file from the upload dialog does not unintentionally delete successfully upload images. This resolves issues with accidental image loss during file upload.

Do not broadcast the delete error as this is a silent error 



https://github.com/user-attachments/assets/69065f1e-3ea8-4e84-a336-04063a0f701b


## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Look at video of current dev 

