### PR TITLE
Remove @types/eslint__js as no longer needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@testing-library/react": "16.1.0",
     "@testing-library/user-event": "14.5.2",
     "@types/eslint-plugin-jsx-a11y": "6.10.0",
-    "@types/eslint__js": "8.42.3",
     "@types/react-router-dom": "5.3.3",
     "@vitest/coverage-v8": "3.1.2",
     "cross-env": "7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,15 +2157,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint__js@npm:8.42.3":
-  version: 8.42.3
-  resolution: "@types/eslint__js@npm:8.42.3"
-  dependencies:
-    "@types/eslint": "npm:*"
-  checksum: 10c0/ccc5180b92155929a089ffb03ed62625216dcd5e46dd3197c6f82370ce8b52c7cb9df66c06b0a3017995409e023bc9eafe5a3f009e391960eacefaa1b62d9a56
-  languageName: node
-  linkType: hard
-
 "@types/estree@npm:*, @types/estree@npm:1.0.7, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
   version: 1.0.7
   resolution: "@types/estree@npm:1.0.7"
@@ -5813,7 +5804,6 @@ __metadata:
     "@testing-library/react": "npm:16.1.0"
     "@testing-library/user-event": "npm:14.5.2"
     "@types/eslint-plugin-jsx-a11y": "npm:6.10.0"
-    "@types/eslint__js": "npm:8.42.3"
     "@types/node": "npm:^22.0.0"
     "@types/react": "npm:^18.3.3"
     "@types/react-dom": "npm:^18.3.0"


### PR DESCRIPTION
## Description

Instead of https://github.com/ral-facilities/inventory-management-system/pull/1396. I double checked and this package is no longer needed as the types come with `@eslint/js` now anyway. It might have been left by accident, SciGateway and OG don't have it either.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
