### PR TITLE
Remove @eslint/compat as no longer required for react-hooks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,3 @@
-import { fixupPluginRules } from '@eslint/compat';
 import eslint from '@eslint/js';
 import queryPlugin from '@tanstack/eslint-plugin-query';
 import prettierPlugin from 'eslint-config-prettier';
@@ -33,9 +32,6 @@ export default tseslint.config(
     },
     plugins: {
       react: reactPlugin,
-      // eslint-plugin-react-hooks doesn't support flat config properly yet
-      // https://github.com/facebook/react/issues/28313
-      'react-hooks': fixupPluginRules(reactHooksPlugin),
       '@tanstack/query': queryPlugin,
       'no-only-tests': noOnlyTestsPlugin,
       'jsx-a11y': jsxA11yPlugin,
@@ -43,6 +39,7 @@ export default tseslint.config(
     extends: [
       eslint.configs.recommended,
       ...tseslint.configs.recommended,
+      reactHooksPlugin.configs['recommended-latest'],
       cypressPlugin.configs.recommended,
       // See https://github.com/prettier/eslint-config-prettier put last
       prettierPlugin,

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
   "packageManager": "yarn@4.9.1",
   "devDependencies": {
     "@babel/eslint-parser": "7.27.0",
-    "@eslint/compat": "1.2.8",
     "@eslint/js": "9.25.1",
     "@tanstack/eslint-plugin-query": "5.73.3",
     "@testing-library/cypress": "10.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,18 +972,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/compat@npm:1.2.8":
-  version: 1.2.8
-  resolution: "@eslint/compat@npm:1.2.8"
-  peerDependencies:
-    eslint: ^9.10.0
-  peerDependenciesMeta:
-    eslint:
-      optional: true
-  checksum: 10c0/1e004c6917220ff1731fdc562ada9ddcbcecc6f3ba2e4b0433fb6d8eddf2a443e009f1f9796b78128b78a0a588c723b78021319055ac6e5dda55c0ace346496b
-  languageName: node
-  linkType: hard
-
 "@eslint/config-array@npm:^0.20.0":
   version: 0.20.0
   resolution: "@eslint/config-array@npm:0.20.0"
@@ -5807,7 +5795,6 @@ __metadata:
     "@date-io/date-fns": "npm:^3.2.1"
     "@emotion/react": "npm:^11.11.4"
     "@emotion/styled": "npm:^11.11.5"
-    "@eslint/compat": "npm:1.2.8"
     "@eslint/js": "npm:9.25.1"
     "@hookform/resolvers": "npm:^3.6.0"
     "@mui/icons-material": "npm:^5.15.19"


### PR DESCRIPTION
## Description

Found while doing https://github.com/ral-facilities/scigateway/pull/1439. eslint-plugin-react-hooks now supports the flat config.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build

## Agile board tracking
