### PR TITLE
Update browserslist config to match DG & OG and fix FromAsCasing in dockerfile

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,7 +1,7 @@
 # Dockerfile to build and serve inventory management system
 
 # Build stage
-FROM node:22.15.0-alpine3.21@sha256:ad1aedbcc1b0575074a91ac146d6956476c1f9985994810e4ee02efd932a68fd as builder
+FROM node:22.15.0-alpine3.21@sha256:ad1aedbcc1b0575074a91ac146d6956476c1f9985994810e4ee02efd932a68fd AS builder
 
 WORKDIR /inventory-management-system-build
 

--- a/package.json
+++ b/package.json
@@ -72,9 +72,7 @@
     "cy:run:api": "cross-env TZ=UTC cypress run --spec \"./cypress/e2e/with_api/**/*.cy.ts\""
   },
   "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not op_mini all"
+    "defaults"
   ],
   "packageManager": "yarn@4.9.1",
   "devDependencies": {


### PR DESCRIPTION
## Description

OG and DG now use defaults for the browserslist config, so I updated the SciGateway branch to do the same, and replicating here. Also noticed this warning
![image](https://github.com/user-attachments/assets/6d182b89-4f13-4733-95aa-4d4090b3f8da)

on https://github.com/ral-facilities/ldap-jwt-auth/pull/227/files so fixed here too.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build

## Agile board tracking
