### PR TITLE
Fix systems scrollbar when nothing selected and improve title alignment #1444

### DIFF
--- a/src/systems/systemDetails.component.tsx
+++ b/src/systems/systemDetails.component.tsx
@@ -73,7 +73,8 @@ function SystemDetails(props: SystemDetailsProps) {
         sx={{
           display: 'flex',
           alignItems: 'center',
-          my: 0.625,
+          mt: 0.525,
+          mb: 1.455,
         }}
         spacing={1}
       >

--- a/src/systems/systems.component.tsx
+++ b/src/systems/systems.component.tsx
@@ -332,7 +332,7 @@ function Systems() {
 
   return (
     <>
-      <Box height="100%">
+      <Box>
         <Grid container margin={0} direction="row" alignItems="stretch">
           <Grid
             item
@@ -378,7 +378,7 @@ function Systems() {
                     marginBottom: 'auto',
                     flexWrap: 'no-wrap',
                     // Breadcrumbs and rest
-                    height: getPageHeightCalc('96px + 74px'),
+                    height: getPageHeightCalc('96px + 58px'),
                     // To prevent no subsystems being visible
                     minHeight: '200px',
                   }}


### PR DESCRIPTION
## Description

See #1444. Fixes the issue and improves the alignment of the subsystems and system titles e.g.
Before:
![image](https://github.com/user-attachments/assets/13cdd1fd-a73e-4665-b5a1-6b90f23b7a5a)
After:
![image](https://github.com/user-attachments/assets/e01fc4b2-44ec-4bed-8fef-5e2ca92a60e9)




## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #1444
