### PR TITLE
bugfix: Catalogue category selection persists when navigating #1452

### DIFF
--- a/src/catalogue/category/catalogueCardView.component.tsx
+++ b/src/catalogue/category/catalogueCardView.component.tsx
@@ -379,6 +379,7 @@ function CatalogueCardView() {
       variant: 'outlined',
     },
     // Functions
+    getRowId: (row) => row.id,
     ...onPreservedStatesChange,
     renderTopToolbarCustomActions: ({ table }) => (
       <Box sx={{ display: 'flex' }}>

--- a/src/catalogue/category/catalogueCardView.component.tsx
+++ b/src/catalogue/category/catalogueCardView.component.tsx
@@ -37,6 +37,7 @@ import {
   COLUMN_FILTER_MODE_OPTIONS,
   COLUMN_FILTER_VARIANTS,
   customFilterFunctions,
+  deselectRowById,
   displayTableRowCountText,
   generateUniqueName,
   getInitialColumnFilterFnState,
@@ -499,7 +500,11 @@ function CatalogueCardView() {
   const isCollapsed = table.getState().showColumnFilters;
 
   const cardViewHeight = getPageHeightCalc('80px');
-
+  // Reset table sate when catalogueCategoryId changes
+  // This ensures that the table is reset when navigating to a different category
+  React.useEffect(() => {
+    table.reset();
+  }, [catalogueCategoryId, table]);
   return (
     <Paper
       component={Grid}
@@ -592,7 +597,12 @@ function CatalogueCardView() {
           />
           <DeleteCatalogueCategoryDialog
             open={menuDialogOpen === 'delete'}
-            onClose={() => setMenuDialogOpen(false)}
+            onClose={({ successfulDeletion }) => {
+              setMenuDialogOpen(false);
+              if (successfulDeletion && selectedCatalogueCategory) {
+                deselectRowById(selectedCatalogueCategory.id, table);
+              }
+            }}
             catalogueCategory={selectedCatalogueCategory}
             onChangeCatalogueCategory={setSelectedCatalogueCategory}
           />

--- a/src/catalogue/category/deleteCatalogueCategoryDialog.component.test.tsx
+++ b/src/catalogue/category/deleteCatalogueCategoryDialog.component.test.tsx
@@ -85,6 +85,10 @@ describe('delete Catalogue Category dialogue', () => {
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();
     });
+
+    expect(onClose).toHaveBeenCalledWith({
+      successfulDeletion: false,
+    });
   });
 
   it('does not close dialog on background click, or on escape key press', async () => {
@@ -126,6 +130,10 @@ describe('delete Catalogue Category dialogue', () => {
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();
+    });
+
+    expect(onClose).toHaveBeenCalledWith({
+      successfulDeletion: true,
     });
   });
 

--- a/src/catalogue/category/deleteCatalogueCategoryDialog.component.tsx
+++ b/src/catalogue/category/deleteCatalogueCategoryDialog.component.tsx
@@ -17,7 +17,7 @@ import handleIMS_APIError from '../../handleIMS_APIError';
 
 export interface DeleteCatalogueCategoryDialogProps {
   open: boolean;
-  onClose: () => void;
+  onClose: (props: { successfulDeletion: boolean }) => void;
   catalogueCategory: CatalogueCategory | undefined;
   onChangeCatalogueCategory: (
     catalogueCategory: CatalogueCategory | undefined
@@ -37,17 +37,20 @@ const DeleteCatalogueCategoryDialog = (
   const { mutateAsync: deleteCatalogueCategory, isPending: isDeletePending } =
     useDeleteCatalogueCategory();
 
-  const handleClose = React.useCallback(() => {
-    onClose();
-    setError(false);
-    setErrorMessage('');
-  }, [onClose]);
+  const handleClose = React.useCallback(
+    (props: { successfulDeletion: boolean }) => {
+      onClose({ successfulDeletion: props.successfulDeletion });
+      setError(false);
+      setErrorMessage('');
+    },
+    [onClose]
+  );
   const handleDeleteCatalogueCategory = React.useCallback(() => {
     if (catalogueCategory) {
       deleteCatalogueCategory(catalogueCategory.id)
         .then(() => {
           onChangeCatalogueCategory(undefined);
-          onClose();
+          handleClose({ successfulDeletion: true });
         })
         .catch((error: AxiosError) => {
           const response = error.response?.data as APIError;
@@ -67,8 +70,8 @@ const DeleteCatalogueCategoryDialog = (
   }, [
     catalogueCategory,
     deleteCatalogueCategory,
+    handleClose,
     onChangeCatalogueCategory,
-    onClose,
   ]);
 
   return (
@@ -85,7 +88,9 @@ const DeleteCatalogueCategoryDialog = (
         ?
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={() => handleClose({ successfulDeletion: false })}>
+          Cancel
+        </Button>
         <Button
           onClick={handleDeleteCatalogueCategory}
           disabled={isDeletePending || error}

--- a/src/catalogue/items/catalogueItemsTable.component.tsx
+++ b/src/catalogue/items/catalogueItemsTable.component.tsx
@@ -47,6 +47,7 @@ import {
   TableGroupedCell,
   TableHeaderOverflowTip,
   customFilterFunctions,
+  deselectRowById,
   displayTableRowCountText,
   formatDateTimeStrings,
   generateUniqueName,
@@ -1028,7 +1029,12 @@ const CatalogueItemsTable = (props: CatalogueItemsTableProps) => {
         <>
           <DeleteCatalogueItemsDialog
             open={deleteItemDialogOpen}
-            onClose={() => setDeleteItemDialogOpen(false)}
+            onClose={({ successfulDeletion }) => {
+              setDeleteItemDialogOpen(false);
+              if (successfulDeletion && selectedCatalogueItem) {
+                deselectRowById(selectedCatalogueItem.id, table);
+              }
+            }}
             catalogueItem={selectedCatalogueItem}
             onChangeCatalogueItem={setSelectedCatalogueItem}
           />

--- a/src/catalogue/items/deleteCatalogueItemDialog.component.test.tsx
+++ b/src/catalogue/items/deleteCatalogueItemDialog.component.test.tsx
@@ -97,6 +97,10 @@ describe('delete Catalogue Category dialogue', () => {
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();
     });
+
+    expect(onClose).toHaveBeenCalledWith({
+      successfulDeletion: false,
+    });
   });
 
   it('does not close dialog on background click, or on escape key press', async () => {
@@ -138,6 +142,10 @@ describe('delete Catalogue Category dialogue', () => {
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();
+    });
+
+    expect(onClose).toHaveBeenCalledWith({
+      successfulDeletion: true,
     });
   });
 

--- a/src/catalogue/items/deleteCatalogueItemDialog.component.tsx
+++ b/src/catalogue/items/deleteCatalogueItemDialog.component.tsx
@@ -17,7 +17,7 @@ import handleIMS_APIError from '../../handleIMS_APIError';
 
 export interface DeleteCatalogueItemDialogProps {
   open: boolean;
-  onClose: () => void;
+  onClose: (props: { successfulDeletion: boolean }) => void;
   catalogueItem: CatalogueItem | undefined;
   onChangeCatalogueItem: (catalogueItem: CatalogueItem | undefined) => void;
 }
@@ -33,16 +33,19 @@ const DeleteCatalogueItemDialog = (props: DeleteCatalogueItemDialogProps) => {
   const { mutateAsync: deleteCatalogueItem, isPending: isDeletePending } =
     useDeleteCatalogueItem();
 
-  const handleClose = React.useCallback(() => {
-    onClose();
-    setError(false);
-    setErrorMessage('');
-  }, [onClose]);
+  const handleClose = React.useCallback(
+    (props: { successfulDeletion: boolean }) => {
+      onClose({ successfulDeletion: props.successfulDeletion });
+      setError(false);
+      setErrorMessage('');
+    },
+    [onClose]
+  );
   const handleDeleteCatalogueCategory = React.useCallback(() => {
     if (catalogueItem) {
       deleteCatalogueItem(catalogueItem.id)
         .then(() => {
-          onClose();
+          handleClose({ successfulDeletion: true });
           onChangeCatalogueItem(undefined);
         })
         .catch((error: AxiosError) => {
@@ -60,7 +63,7 @@ const DeleteCatalogueItemDialog = (props: DeleteCatalogueItemDialogProps) => {
       setError(true);
       setErrorMessage('No data provided, Please refresh and try again');
     }
-  }, [catalogueItem, deleteCatalogueItem, onChangeCatalogueItem, onClose]);
+  }, [catalogueItem, deleteCatalogueItem, handleClose, onChangeCatalogueItem]);
 
   return (
     <Dialog open={open} maxWidth="lg">
@@ -76,7 +79,9 @@ const DeleteCatalogueItemDialog = (props: DeleteCatalogueItemDialogProps) => {
         ?
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={() => handleClose({ successfulDeletion: false })}>
+          Cancel
+        </Button>
         <Button
           onClick={handleDeleteCatalogueCategory}
           disabled={isDeletePending || error}

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -575,3 +575,14 @@ export function parseErrorResponse(errorMessage: string): string {
 
   return returnMessage;
 }
+
+export const deselectRowById = <TData extends MRT_RowData>(
+  id: string,
+  table: MRT_TableInstance<TData>
+) => {
+  table.setRowSelection((old) => {
+    const updated: typeof old = { ...old };
+    delete updated[id];
+    return updated;
+  });
+};


### PR DESCRIPTION
## Description

see #1452

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Check If the selected persist in a deeply nested catalogue category with content catalogue categories
- [ ]  Check if the deleting catalogue category deselects properly 


## Agile board tracking

closes #1452
