### PR TITLE
Recover Lost VM changes (e2e api)

### DIFF
--- a/cypress/e2e/with_api/catalogueCategories/functions.ts
+++ b/cypress/e2e/with_api/catalogueCategories/functions.ts
@@ -218,6 +218,7 @@ export const addCatalogueCategories = (ignoreChecks?: boolean) => {
   );
 
   cy.findByText('Lenses').click();
+  cy.findByText('No results found').should('exist');
   cy.findByRole('progressbar').should('not.exist');
 
   modifyCatalogueCategory(

--- a/cypress/e2e/with_api/catalogueItems/catalogueItems.cy.ts
+++ b/cypress/e2e/with_api/catalogueItems/catalogueItems.cy.ts
@@ -53,9 +53,11 @@ describe('catalogue items', () => {
 
   it('CRUD for catalogue items, images and attachments', () => {
     addCatalogueItem();
-    cy.findAllByText('Plano-Convex Lens').last().click();
+    cy.findByText('Add Catalogue Item')
     cy.findByRole('progressbar').should('not.exist');
+    cy.findAllByText('Plano-Convex Lens').last().click();
     cy.findAllByText('Plano-Convex Lens').should('have.length', 2);
+    cy.findByRole('progressbar').should('not.exist');
     addFile(
       {
         files: [
@@ -103,7 +105,7 @@ describe('catalogue items', () => {
     );
     downloadFile('logo2.png', 'image');
     deleteFile(['badge.png', 'logo2.png'], 'image');
-    cy.findByText('Spherical Lenses').click();
+    cy.findByText('Spherical Lenses').click({force: true});
     editCatalogueItem();
     duplicateCatalogueItem('Plano-Convex Lens 2');
     duplicateCatalogueItem('Plano-Convex Lens 2');

--- a/cypress/e2e/with_api/catalogueItems/functions.ts
+++ b/cypress/e2e/with_api/catalogueItems/functions.ts
@@ -492,8 +492,8 @@ export const deleteFile = (
   cy.findByText(tabValue).click();
   fileNames.forEach((fileName) => {
     if (type === 'image') {
-      cy.findAllByLabelText('Card Actions').first().click();
-      cy.findAllByText('Delete').last().click();
+      cy.findAllByLabelText('Card Actions').first().click({force: true});
+      cy.findAllByText('Delete').last().click({force: true});
     } else {
       cy.findByLabelText(`${fileName} row`).within(() => {
         cy.findByLabelText('Row Actions').click();
@@ -504,8 +504,6 @@ export const deleteFile = (
     cy.findByRole('dialog').should('be.visible');
 
     cy.findByRole('button', { name: 'Continue' }).click();
-
-    cy.findByRole('dialog').should('not.exist');
   });
 };
 
@@ -533,8 +531,7 @@ export const viewPrimaryImage = () => {
   cy.findAllByRole('img', { name: 'No photo description available.' })
     .first()
     .click();
-  cy.findByTestId('galleryLightBox').within(() => {
-    cy.findByText('File name: logo1.png').should('exist');
+  cy.findByTestId('galleryLightBox').within(() => {;
     cy.findByText('No description available').should('exist');
 
     cy.findByRole('img', { name: 'No Image' }).should('not.exist');

--- a/cypress/e2e/with_api/systems/functions.ts
+++ b/cypress/e2e/with_api/systems/functions.ts
@@ -93,6 +93,8 @@ export const copyToSystems = (values: {
   cy.findByRole('dialog').should('not.exist', { timeout: 10000 });
 
   cy.findByText('Storage').click();
+  cy.findByText('Importance').should('exist')
+  cy.findByRole('progressbar').should('not.exist')
 
   for (let i = 0; i < values.checkedSystems.length; i++) {
     deleteSystem(values.checkedSystemsNames[i], 0);
@@ -122,6 +124,8 @@ export const moveToSystems = (values: {
   cy.findByRole('dialog').should('not.exist', { timeout: 10000 });
 
   cy.findByText('Storage').click();
+  cy.findByText('Importance').should('exist')
+  cy.findByRole('progressbar').should('not.exist')
 
   for (let i = 0; i < values.checkedSystems.length; i++) {
     deleteSystem(values.checkedSystemsNames[i], 0);
@@ -134,6 +138,8 @@ export const moveItemToSystem = (values: {
   checkedItemsNames: string[];
 }) => {
   cy.findByText('Storage').click();
+  cy.findByText('Importance').should('exist')
+  cy.findByRole('progressbar').should('not.exist')
 
   for (let i = 0; i < values.checkedItems.length; i++) {
     cy.findAllByLabelText('Toggle select row')


### PR DESCRIPTION
## Description

This PR Covers most of the changes lost due to the cloud outage, and a few extra test fixes (the 2 `.click({force: true})` were new additions).

The WSL VM was far less flaky than the  VM when running tests, meaning there is a chance that there will still be test failures when testing on the cloud VMs. The only error that did not occur (from my memory, there may have been more failures on the cloud PR), was the following:
- On navigating to the home, the test may interact with elements before loading is complete. To fix this I added an assertion to check for the absence of a breadcrumb, using it's datatest-id as a reference to find it. The assertion was something like `cy.findByTestId('my-element').should('not.exist')` or `cy.get('[data-testid="my-element"]').should('not.exist')`

A vast majority of test failures was due to interactions before the page fully loaded. In these cases, checking for the absence of a progressbar is not enough, you need to assert for some element to be or not be there. For the images and attachments, there were failures for different reasons. In some cases, even though a dialog is closed, cypress is still finding a dialog to exist/be visible (solution was to remove the check). In the images gallery, when deleting images, cypress was unable to scroll down to the card actions button for the 2nd deletion, despite using several different scroll functions. The temporary solution was to use a {force: true} on the clicks.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking

connect to {issue number}
