### PR TITLE
Actually handle unauthorised route plugin config

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -168,6 +168,7 @@ export const fetchSettings =
                   order: route['order'] ?? 0,
                   hideFromMenu: route['hideFromMenu'] ?? false,
                   admin: route['admin'] ?? false,
+                  unauthorised: route['unauthorised'] ?? false,
                   helpSteps:
                     index === 0 && 'helpSteps' in settings
                       ? settings['helpSteps']

--- a/src/state/actions/actions.types.tsx
+++ b/src/state/actions/actions.types.tsx
@@ -12,5 +12,6 @@ export interface PluginRoute {
   displayName: string;
   admin?: boolean;
   hideFromMenu?: boolean;
+  unauthorised?: boolean;
   order: number;
 }


### PR DESCRIPTION
## Description

I added the `unauthorised: true` part to the IMS homepage but didn't actually check whether IMS was actually parsing & sending that setting. This caused the issue Joel was having with the homepage not being open.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Check homepage is actually open now when running in SGW