### PR TITLE
Remove python install from CI #1520

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -89,11 +89,6 @@ jobs:
           repository: ral-facilities/inventory-management-system-api
           ref: develop
 
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.12'
-
       # This is required as need to setup api in a different directory as checkout will attempt delete
       # all existing files which in this case will include a data directory created by docker causing
       # a permission error (checkout action also can't specify a different directory to clone into)


### PR DESCRIPTION
## Description

See title. Just following on from backend upgrades to python3.13, but removing as isn't needed anymore.

As a side note, we are using node 22 in the docker images but haven't updated the CI from 20, so should probably trigger the renovate update for that soon so we test on it. (seems we have the same on main https://github.com/ral-facilities/inventory-management-system/pull/1367/files)

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #1520
