### PR TITLE
Fix codecov bundler analysis not running in the CI #1533

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -249,7 +249,8 @@ jobs:
       - name: Build app for production
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: yarn build
+        # Override the value used in the .env.production
+        run: VITE_APP_INCLUDE_CODECOV=true yarn build
 
   docker:
     # This job triggers only if all the other jobs succeed. It builds the Docker image and if successful,

--- a/src/items/__snapshots__/itemsDetailsPanel.component.test.tsx.snap
+++ b/src/items/__snapshots__/itemsDetailsPanel.component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Catalogue Items details panel > renders details panel correctly (None values for telephone and url) 1`] = `
+exports[`Items details panel > renders details panel correctly (None values for telephone and url) 1`] = `
 <DocumentFragment>
   <div
     class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-smpqgx-MuiGrid2-root"
@@ -601,7 +601,7 @@ exports[`Catalogue Items details panel > renders details panel correctly (None v
 </DocumentFragment>
 `;
 
-exports[`Catalogue Items details panel > renders details panel correctly (no dates) 1`] = `
+exports[`Items details panel > renders details panel correctly (no dates) 1`] = `
 <DocumentFragment>
   <div
     class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-smpqgx-MuiGrid2-root"
@@ -1202,7 +1202,7 @@ exports[`Catalogue Items details panel > renders details panel correctly (no dat
 </DocumentFragment>
 `;
 
-exports[`Catalogue Items details panel > renders details panel correctly (when there are no Notes) 1`] = `
+exports[`Items details panel > renders details panel correctly (when there are no Notes) 1`] = `
 <DocumentFragment>
   <div
     class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-smpqgx-MuiGrid2-root"
@@ -1803,7 +1803,7 @@ exports[`Catalogue Items details panel > renders details panel correctly (when t
 </DocumentFragment>
 `;
 
-exports[`Catalogue Items details panel > renders details panel correctly 1`] = `
+exports[`Items details panel > renders details panel correctly 1`] = `
 <DocumentFragment>
   <div
     class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-smpqgx-MuiGrid2-root"
@@ -2397,7 +2397,7 @@ exports[`Catalogue Items details panel > renders details panel correctly 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Catalogue Items details panel > renders manufacturer panel correctly 1`] = `
+exports[`Items details panel > renders manufacturer panel correctly 1`] = `
 <DocumentFragment>
   <div
     class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-smpqgx-MuiGrid2-root"
@@ -3018,7 +3018,7 @@ exports[`Catalogue Items details panel > renders manufacturer panel correctly 1`
 </DocumentFragment>
 `;
 
-exports[`Catalogue Items details panel > renders notes panel correctly 1`] = `
+exports[`Items details panel > renders notes panel correctly 1`] = `
 <DocumentFragment>
   <div
     class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-smpqgx-MuiGrid2-root"
@@ -3639,7 +3639,7 @@ exports[`Catalogue Items details panel > renders notes panel correctly 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Catalogue Items details panel > renders properties panel correctly (empty property list) 1`] = `
+exports[`Items details panel > renders properties panel correctly (empty property list) 1`] = `
 <DocumentFragment>
   <div
     class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-smpqgx-MuiGrid2-root"
@@ -4145,7 +4145,7 @@ exports[`Catalogue Items details panel > renders properties panel correctly (emp
 </DocumentFragment>
 `;
 
-exports[`Catalogue Items details panel > renders properties panel correctly 1`] = `
+exports[`Items details panel > renders properties panel correctly 1`] = `
 <DocumentFragment>
   <div
     class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-smpqgx-MuiGrid2-root"

--- a/src/items/itemsDetailsPanel.component.test.tsx
+++ b/src/items/itemsDetailsPanel.component.test.tsx
@@ -10,7 +10,7 @@ import ItemsDetailsPanel, {
   ItemsDetailsPanelProps,
 } from './itemsDetailsPanel.component';
 
-describe('Catalogue Items details panel', () => {
+describe('Items details panel', () => {
   let user: UserEvent;
   let props: ItemsDetailsPanelProps;
   const createView = () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,7 +69,7 @@ export default defineConfig(({ mode }) => {
     plugins.push(
       codecovVitePlugin({
         enableBundleAnalysis: env.CODECOV_TOKEN !== undefined,
-        bundleName: 'inventory-management-system',
+        bundleName: 'prod-build',
         uploadToken: env.CODECOV_TOKEN,
       })
     );


### PR DESCRIPTION
## Description

See #1533, should hopefully fix the bundler analysis not working properly. Seems we were never really enabling it when running `yarn build` on the CI due to the .env.production file getting in the way. Have overridden the relevant environment variable on the CI instead as vite will use the file to override variables that havent already been set. Adjusted the name of the bundle as the naming in codecov already includes the project name, and wants a more specific one for what kind of bundle it is, so went for "prod-build".

Also noticed the name of the tests in itemDetailsPanel said it was for Catalogue Items while looking at the CI so fixed it.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review bundle analysis on codecov (e.g. https://app.codecov.io/gh/ral-facilities/inventory-management-system/bundles/fix-codecov-bundler-analysis-%231533/prod-build-inventory-management-system-umd)

## Agile board tracking

Closes #1533
