### PR TITLE
refactored useForm for units and usage statuses dialogs

### DIFF
--- a/src/admin/units/unitsDialog.component.tsx
+++ b/src/admin/units/unitsDialog.component.tsx
@@ -13,7 +13,6 @@ import {
 import { AxiosError } from 'axios';
 import React from 'react';
 import { useForm } from 'react-hook-form';
-import { UnitPost } from '../../api/api.types';
 import { usePostUnit } from '../../api/units';
 import { UnitSchema } from '../../form.schemas';
 import handleIMS_APIError from '../../handleIMS_APIError';
@@ -51,7 +50,7 @@ function UnitsDialog(props: UnitsDialogProps) {
   }, [clearErrors, onClose, reset]);
 
   const handleAddUnit = React.useCallback(
-    (unitData: UnitPost) => {
+    (unitData: z.output<typeof UnitSchema>) => {
       postUnit(unitData)
         .then(() => handleClose())
         .catch((error: AxiosError) => {
@@ -67,10 +66,6 @@ function UnitsDialog(props: UnitsDialogProps) {
     },
     [postUnit, handleClose, setError]
   );
-
-  const onSubmit = (data: UnitPost) => {
-    handleAddUnit(data);
-  };
 
   return (
     <Dialog open={open} maxWidth="sm" fullWidth>
@@ -116,7 +111,7 @@ function UnitsDialog(props: UnitsDialogProps) {
           <Button
             variant="outlined"
             sx={{ width: '50%', mx: 1 }}
-            onClick={handleSubmit(onSubmit)}
+            onClick={handleSubmit(handleAddUnit)}
             disabled={isAddPending || Object.values(errors).length !== 0}
             endIcon={isAddPending ? <CircularProgress size={20} /> : null}
           >

--- a/src/admin/units/unitsDialog.component.tsx
+++ b/src/admin/units/unitsDialog.component.tsx
@@ -17,6 +17,7 @@ import { UnitPost } from '../../api/api.types';
 import { usePostUnit } from '../../api/units';
 import { UnitSchema } from '../../form.schemas';
 import handleIMS_APIError from '../../handleIMS_APIError';
+import z from 'zod';
 
 export interface UnitsDialogProps {
   open: boolean;
@@ -33,7 +34,11 @@ function UnitsDialog(props: UnitsDialogProps) {
     setError,
     clearErrors,
     reset,
-  } = useForm<UnitPost>({
+  } = useForm<
+    z.input<typeof UnitSchema>,
+    undefined,
+    z.output<typeof UnitSchema>
+  >({
     resolver: zodResolver(UnitSchema),
   });
 

--- a/src/admin/usageStatuses/usageStatusDialog.component.tsx
+++ b/src/admin/usageStatuses/usageStatusDialog.component.tsx
@@ -17,6 +17,7 @@ import { UsageStatusPost } from '../../api/api.types';
 import { usePostUsageStatus } from '../../api/usageStatuses';
 import { UsageStatusSchema } from '../../form.schemas';
 import handleIMS_APIError from '../../handleIMS_APIError';
+import z from 'zod';
 
 export interface UsageStatusDialogProps {
   open: boolean;
@@ -33,7 +34,11 @@ function UsageStatusDialog(props: UsageStatusDialogProps) {
     setError,
     clearErrors,
     reset,
-  } = useForm<UsageStatusPost>({
+  } = useForm<
+    z.input<typeof UsageStatusSchema>,
+    undefined,
+    z.output<typeof UsageStatusSchema>
+  >({
     resolver: zodResolver(UsageStatusSchema),
   });
 

--- a/src/admin/usageStatuses/usageStatusDialog.component.tsx
+++ b/src/admin/usageStatuses/usageStatusDialog.component.tsx
@@ -13,7 +13,6 @@ import {
 import { AxiosError } from 'axios';
 import React from 'react';
 import { useForm } from 'react-hook-form';
-import { UsageStatusPost } from '../../api/api.types';
 import { usePostUsageStatus } from '../../api/usageStatuses';
 import { UsageStatusSchema } from '../../form.schemas';
 import handleIMS_APIError from '../../handleIMS_APIError';
@@ -52,7 +51,7 @@ function UsageStatusDialog(props: UsageStatusDialogProps) {
   }, [clearErrors, onClose, reset]);
 
   const handleAddUsageStatus = React.useCallback(
-    (usageStatusData: UsageStatusPost) => {
+    (usageStatusData: z.output<typeof UsageStatusSchema>) => {
       postUsageStatus(usageStatusData)
         .then(() => handleClose())
         .catch((error: AxiosError) => {
@@ -68,9 +67,6 @@ function UsageStatusDialog(props: UsageStatusDialogProps) {
     },
     [postUsageStatus, handleClose, setError]
   );
-  const onSubmit = (data: UsageStatusPost) => {
-    handleAddUsageStatus(data);
-  };
 
   return (
     <Dialog open={open} maxWidth="sm" fullWidth>
@@ -116,7 +112,7 @@ function UsageStatusDialog(props: UsageStatusDialogProps) {
           <Button
             variant="outlined"
             sx={{ width: '50%', mx: 1 }}
-            onClick={handleSubmit(onSubmit)}
+            onClick={handleSubmit(handleAddUsageStatus)}
             disabled={isAddPending || Object.values(errors).length !== 0}
             endIcon={isAddPending ? <CircularProgress size={20} /> : null}
           >


### PR DESCRIPTION
## Description

Implement new `useForm` syntax for units and usage statuses dialogs due to upgrade to react-hook-form v7.62.0 (see #1391 )

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
