### PR TITLE
Bump node version to v22 on CI to match project & docker #1244

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          node-version: 22.21
           cache: 'yarn'
 
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          node-version: 22.21
           cache: 'yarn'
 
       - name: Install dependencies
@@ -190,7 +190,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          node-version: 22.21
           cache: 'yarn'
 
       - name: Install dependencies
@@ -239,7 +239,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          node-version: 22.21
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies
@@ -190,7 +190,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies
@@ -239,7 +239,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Specify a base image
-FROM node:22.15.0-alpine3.21@sha256:ad1aedbcc1b0575074a91ac146d6956476c1f9985994810e4ee02efd932a68fd
+FROM node:22.21-alpine3.22@sha256:b2358485e3e33bc3a33114d2b1bdb18cdbe4df01bd2b257198eb51beb1f026c5
 
 # Set the working directory
 WORKDIR /inventory-management-system-run

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,7 +1,7 @@
 # Dockerfile to build and serve inventory management system
 
 # Build stage
-FROM node:22.15.0-alpine3.21@sha256:ad1aedbcc1b0575074a91ac146d6956476c1f9985994810e4ee02efd932a68fd AS builder
+FROM node:22.21-alpine3.22@sha256:b2358485e3e33bc3a33114d2b1bdb18cdbe4df01bd2b257198eb51beb1f026c5 AS builder
 
 WORKDIR /inventory-management-system-build
 

--- a/src/catalogue/category/catalogueCardView.component.test.tsx
+++ b/src/catalogue/category/catalogueCardView.component.test.tsx
@@ -405,7 +405,7 @@ describe('CardView', () => {
       expect(await screen.findByText('Test 1')).toBeInTheDocument();
 
       expect(clearFiltersButton).toBeDisabled();
-    });
+    }, 10000);
 
     it('renders the multi-select filter mode dropdown correctly', async () => {
       createView();

--- a/src/catalogue/category/catalogueCategoryDialog.component.test.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.test.tsx
@@ -489,7 +489,7 @@ describe('Catalogue Category Dialog', () => {
       });
 
       expect(onClose).toHaveBeenCalled();
-    }, 20000);
+    }, 25000);
 
     it('create a catalogue category with content being catalogue items, changes the type of the allowed values to text before submission', async () => {
       createView();
@@ -574,7 +574,7 @@ describe('Catalogue Category Dialog', () => {
       });
 
       expect(onClose).toHaveBeenCalled();
-    }, 25000);
+    }, 30000);
 
     it('create a catalogue category with content being catalogue items, changes the type of the allowed values to boolean before submission', async () => {
       createView();
@@ -889,7 +889,7 @@ describe('Catalogue Category Dialog', () => {
       expect(incorrectTypeHelperTexts.length).toEqual(1);
 
       expect(onClose).not.toHaveBeenCalled();
-    }, 20000);
+    }, 25000);
 
     it('displays duplicate values and incorrect type error and deletes an allowed value to check if errors states are in correct location (allowed_values list of numbers)', async () => {
       createView();
@@ -936,7 +936,7 @@ describe('Catalogue Category Dialog', () => {
       const duplicateHelperTexts2 = screen.queryByText('Duplicate value.');
 
       expect(duplicateHelperTexts2).not.toBeInTheDocument();
-    }, 25000);
+    }, 30000);
 
     it('displays invalid type errors (allowed_values list of numbers)', async () => {
       createView();

--- a/src/catalogue/category/catalogueCategoryDialog.component.test.tsx
+++ b/src/catalogue/category/catalogueCategoryDialog.component.test.tsx
@@ -54,11 +54,19 @@ describe('Catalogue Category Dialog', () => {
 
     if (values.newFormFields) {
       // Assume want a leaf now
-      await user.click(screen.getByLabelText('Catalogue Items'));
+      await waitFor(
+        async () => await user.click(screen.getByLabelText('Catalogue Items'))
+      );
+      expect(
+        await screen.findByTestId('properties-table-container')
+      ).toBeInTheDocument();
 
       for (let i = 0; i < values.newFormFields.length; i++) {
         const addButton = screen.getByText('Add Property');
-        await user.click(addButton);
+        await waitFor(async () => await user.click(addButton));
+        expect(
+          await screen.findByRole('dialog', { name: 'Add Property' })
+        ).toBeInTheDocument();
 
         const field = values.newFormFields[i];
 
@@ -384,7 +392,7 @@ describe('Catalogue Category Dialog', () => {
       });
 
       expect(onClose).toHaveBeenCalled();
-    }, 15000);
+    }, 20000);
 
     it('create a catalogue category with content being catalogue items and cancel a catalogue item property', async () => {
       createView();
@@ -481,7 +489,7 @@ describe('Catalogue Category Dialog', () => {
       });
 
       expect(onClose).toHaveBeenCalled();
-    }, 15000);
+    }, 20000);
 
     it('create a catalogue category with content being catalogue items, changes the type of the allowed values to text before submission', async () => {
       createView();
@@ -566,7 +574,7 @@ describe('Catalogue Category Dialog', () => {
       });
 
       expect(onClose).toHaveBeenCalled();
-    }, 15000);
+    }, 25000);
 
     it('create a catalogue category with content being catalogue items, changes the type of the allowed values to boolean before submission', async () => {
       createView();
@@ -649,7 +657,7 @@ describe('Catalogue Category Dialog', () => {
       });
 
       expect(onClose).toHaveBeenCalled();
-    }, 15000);
+    }, 25000);
 
     it('create a catalogue category with content being catalogue items, changes from have allowed values list to any', async () => {
       createView();
@@ -736,7 +744,7 @@ describe('Catalogue Category Dialog', () => {
       });
 
       expect(onClose).toHaveBeenCalled();
-    }, 15000);
+    }, 25000);
 
     it('create a catalogue category with content being catalogue items (allowed_values list of strings)', async () => {
       createView();
@@ -785,7 +793,7 @@ describe('Catalogue Category Dialog', () => {
       });
 
       expect(onClose).toHaveBeenCalled();
-    }, 15000);
+    }, 20000);
 
     it('displays an error message when the name field are not filled', async () => {
       createView();
@@ -881,7 +889,7 @@ describe('Catalogue Category Dialog', () => {
       expect(incorrectTypeHelperTexts.length).toEqual(1);
 
       expect(onClose).not.toHaveBeenCalled();
-    }, 15000);
+    }, 20000);
 
     it('displays duplicate values and incorrect type error and deletes an allowed value to check if errors states are in correct location (allowed_values list of numbers)', async () => {
       createView();
@@ -928,7 +936,7 @@ describe('Catalogue Category Dialog', () => {
       const duplicateHelperTexts2 = screen.queryByText('Duplicate value.');
 
       expect(duplicateHelperTexts2).not.toBeInTheDocument();
-    }, 20000);
+    }, 25000);
 
     it('displays invalid type errors (allowed_values list of numbers)', async () => {
       createView();

--- a/src/catalogue/category/property/propertyDialog.component.test.tsx
+++ b/src/catalogue/category/property/propertyDialog.component.test.tsx
@@ -199,7 +199,7 @@ describe('PropertyDialog', () => {
           unit_id: '5',
         }
       );
-    });
+    }, 10000);
 
     it('adds a new property with allowed values (type string to type number)', async () => {
       createView();

--- a/src/common/attachments/uploadAttachmentsDialog.component.tsx
+++ b/src/common/attachments/uploadAttachmentsDialog.component.tsx
@@ -90,6 +90,15 @@ const UploadAttachmentsDialog = (props: UploadAttachmentsDialogProps) => {
       .use(ProgressBar<UppyUploadMetadata, AwsBody>)
   );
 
+  // Destroy uppy instance on unmount (Should also avoid errors in tests e.g. 'ReferenceError: window is not defined' from code
+  // executing after tests have completed)
+  React.useEffect(
+    () => () => {
+      uppy.destroy();
+    },
+    [uppy]
+  );
+
   uppy.getPlugin('DragDrop')?.setOptions({
     locale: {
       strings: { dropPasteFiles: `Drop attachments here or %{browseFiles}` },

--- a/src/common/images/uploadImagesDialog.component.tsx
+++ b/src/common/images/uploadImagesDialog.component.tsx
@@ -74,6 +74,15 @@ const UploadImagesDialog = (props: UploadImagesDialogProps) => {
     return newUppy;
   });
 
+  // Destroy uppy instance on unmount (Should also avoid errors in tests e.g. 'ReferenceError: window is not defined' from code
+  // executing after tests have completed)
+  React.useEffect(
+    () => () => {
+      uppy.destroy();
+    },
+    [uppy]
+  );
+
   const { files = {}, error, recoveredState } = uppy.getState();
   const { isAllComplete } = uppy.getObjectOfFilesPerState();
 

--- a/src/items/itemDialog.component.test.tsx
+++ b/src/items/itemDialog.component.test.tsx
@@ -662,7 +662,7 @@ describe('ItemDialog', () => {
 
       await user.clear(screen.getByLabelText('Quantity'));
       await user.clear(screen.getByLabelText('Starting value'));
-    }, 10000);
+    }, 15000);
 
     it('adds an item (case empty string with spaces returns null and change property boolean values)', async () => {
       createView();
@@ -805,7 +805,7 @@ describe('ItemDialog', () => {
       });
 
       expect(screen.getByRole('button', { name: 'Finish' })).not.toBeDisabled();
-    }, 10000);
+    }, 15000);
 
     it('displays error message when property values type is incorrect', async () => {
       createView();
@@ -887,7 +887,7 @@ describe('ItemDialog', () => {
           screen.queryByText('Please enter a valid number.')
         ).not.toBeInTheDocument();
       });
-    }, 10000);
+    }, 15000);
 
     it('displays error message when mandatory property with allowed values is missing', async () => {
       props = {

--- a/src/items/itemDialog.component.test.tsx
+++ b/src/items/itemDialog.component.test.tsx
@@ -1217,7 +1217,7 @@ describe('ItemDialog', () => {
         system_id: '657f8c3b2a1b4e5d8f9b3c4e5',
         usage_status_id: '2',
       });
-    }, 10000);
+    }, 15000);
 
     it('edit an item (all input values) when there is no catalogue category given', async () => {
       // Force the catalogue category to be fetched
@@ -1278,7 +1278,7 @@ describe('ItemDialog', () => {
         system_id: '657f8c3b2a1b4e5d8f9b3c4e5',
         usage_status_id: '2',
       });
-    }, 10000);
+    }, 15000);
 
     it('edits an item where the item property has an allowed list of values', async () => {
       props = {

--- a/src/items/itemDialog.component.test.tsx
+++ b/src/items/itemDialog.component.test.tsx
@@ -551,7 +551,7 @@ describe('ItemDialog', () => {
       expect(
         await screen.findByRole('button', { name: 'Finish' })
       ).not.toBeDisabled();
-    }, 10000);
+    }, 15000);
 
     it('displays placement and items details error message user skips to last step and presses finish', async () => {
       createView();
@@ -561,7 +561,7 @@ describe('ItemDialog', () => {
       await user.click(screen.getByRole('button', { name: 'Finish' }));
 
       expect(
-        screen.getByText('Please select a parent system')
+        await screen.findByText('Please select a parent system')
       ).toBeInTheDocument();
       expect(screen.getByText('Invalid item details')).toBeInTheDocument();
       expect(

--- a/src/items/itemsTable.component.test.tsx
+++ b/src/items/itemsTable.component.test.tsx
@@ -332,7 +332,7 @@ describe('Items Table', () => {
     expect(screen.getByLabelText('Notes')).toHaveValue(
       '6Y5XTJfBrNNx8oltI9HE\n\nThis is a copy of the item with this Serial Number: 5YUQDDjKpz2z'
     );
-  });
+  }, 15000);
 
   it('can open the duplicate dialog and checks that the notes have been updated when notes is null', async () => {
     props.catalogueCategory = getCatalogueCategoryById(

--- a/src/systems/systemItemsTable.component.test.tsx
+++ b/src/systems/systemItemsTable.component.test.tsx
@@ -389,7 +389,7 @@ describe('SystemItemsTable', () => {
     expect(screen.getByLabelText('Notes')).toHaveValue(
       'ihwCjMdJ4n7KKcaM34Lj\n\nThis is a copy of the item with this Serial Number: 5xE1KSraISvu'
     );
-  });
+  }, 15000);
 
   it('can open the duplicate dialog and checks that the notes have been updated when notes is null', async () => {
     props.system = getSystemById('656da8ef9cba7a76c6f81a5d');
@@ -436,7 +436,7 @@ describe('SystemItemsTable', () => {
     expect(screen.getByLabelText('Notes')).toHaveValue(
       '\n\nThis is a copy of the item with this Serial Number: RncNJlDk1pXC'
     );
-  }, 15000);
+  }, 20000);
 
   it('can open the duplicate dialog and checks that the notes have been updated with no serial number', async () => {
     props.system = getSystemById('656da8ef9cba7a76c6f81a5d');
@@ -483,7 +483,7 @@ describe('SystemItemsTable', () => {
     expect(screen.getByLabelText('Notes')).toHaveValue(
       'MJuSPgXEiXmBbf1Vlq4B\n\nThis is a copy of the item with this Serial Number: No serial number'
     );
-  }, 15000);
+  }, 20000);
 
   it('can open the delete dialog and close it again', async () => {
     createView();

--- a/src/systems/systemItemsTable.component.test.tsx
+++ b/src/systems/systemItemsTable.component.test.tsx
@@ -436,7 +436,7 @@ describe('SystemItemsTable', () => {
     expect(screen.getByLabelText('Notes')).toHaveValue(
       '\n\nThis is a copy of the item with this Serial Number: RncNJlDk1pXC'
     );
-  });
+  }, 15000);
 
   it('can open the duplicate dialog and checks that the notes have been updated with no serial number', async () => {
     props.system = getSystemById('656da8ef9cba7a76c6f81a5d');
@@ -483,7 +483,7 @@ describe('SystemItemsTable', () => {
     expect(screen.getByLabelText('Notes')).toHaveValue(
       'MJuSPgXEiXmBbf1Vlq4B\n\nThis is a copy of the item with this Serial Number: No serial number'
     );
-  });
+  }, 15000);
 
   it('can open the delete dialog and close it again', async () => {
     createView();

--- a/src/systems/systemsTableView.component.test.tsx
+++ b/src/systems/systemsTableView.component.test.tsx
@@ -51,9 +51,8 @@ describe('SystemsTableView', () => {
       expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
     );
 
-    mockSystemsData.forEach((system) =>
-      expect(screen.getByText(system.name)).toBeInTheDocument()
-    );
+    for (const system of mockSystemsData)
+      expect(await screen.findByText(system.name)).toBeInTheDocument();
   });
 
   it('renders no results page correctly', async () => {


### PR DESCRIPTION
## Description

Just to close an issue I made a while ago. The latest version is v24, and rennovate is correctly fixing this in that PR (https://github.com/ral-facilities/inventory-management-system/pull/1558) so no idea how it became out of sync. But due to nvm being a bit broken for me, (I cant seem to force the default version and it just resets each time unless I uninstall v22, so may want to fix that/upgrade scigateway too) and because there are some breaking changes looking at the CI, I thought it best to leave it for the moment. Its also only been LTS for 2 days.

I did update to the latest v22 version and fixed the specific version on the CI (I am hoping renovate will keep doing that) so we can even more closely match versions used on the CI and docker images.

This has undone the gains from #1554 unfortunately. CI will fail due to Harbor being down until at least Monday.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #1244
