### PR TITLE
Spares filter button (Bug) #1588

### DIFF
--- a/cypress/e2e/with_mock_data/items.cy.ts
+++ b/cypress/e2e/with_mock_data/items.cy.ts
@@ -518,6 +518,39 @@ describe('Items', () => {
     cy.findByText('WrgqAVk3qUQK').should('exist');
   });
 
+  it('set spares definition filter and checks the banner is still visible when grouped and then and clears the table filters', () => {
+    cy.visit('/catalogue/9/items/11/items');
+    cy.findByText('dfzqkOJbqifO').should('exist');
+    cy.findByText('tenrMn1KOmIg').should('exist');
+    cy.findByText('eUc80U7FqJum').should('exist');
+    cy.findByText('WrgqAVk3qUQK').should('exist');
+    cy.findByRole('button', { name: 'Show Spare Items' }).should(
+      'not.be.disabled'
+    );
+    cy.findByRole('button', { name: 'Show Spare Items' }).click();
+    cy.findByText('dfzqkOJbqifO').should('exist');
+    cy.findByText('tenrMn1KOmIg').should('not.exist');
+    cy.findByText('eUc80U7FqJum').should('not.exist');
+    cy.findByText('WrgqAVk3qUQK').should('not.exist');
+    cy.findByRole('button', { name: 'Show Spare Items' }).should('be.disabled');
+
+    cy.findByText('Spares Definition Filter Applied').should('exist');
+    cy.findByLabelText(
+      'Items that are contained within this system type Storage are classified as spares'
+    ).should('exist');
+
+    cy.findAllByRole('button', { name: 'Column Actions' }).eq(3).click();
+    cy.findByText('Group by Asset Number').click();
+
+    cy.findByText('Spares Definition Filter Applied').should('exist');
+    cy.findByLabelText(
+      'Items that are contained within this system type Storage are classified as spares'
+    ).should('exist');
+
+    cy.findByRole('button', { name: 'Clear Filters' }).click();
+    cy.findByText('DEAbxBGr2M', { exact: false }).should('exist');
+  });
+
   it('navigates to the landing page and navigates back to the table view', () => {
     cy.findByText('5YUQDDjKpz2z').click();
     cy.findByText(

--- a/src/items/__snapshots__/itemsTable.component.test.tsx.snap
+++ b/src/items/__snapshots__/itemsTable.component.test.tsx.snap
@@ -3552,12 +3552,12 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             </span>
                           </div>
                           <input
-                            aria-describedby=":r2l1:-helper-text"
+                            aria-describedby=":r2od:-helper-text"
                             aria-invalid="false"
                             aria-label="Filter by Serial Number"
                             autocomplete="off"
                             class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-110vr2a-MuiInputBase-input-MuiInput-input"
-                            id=":r2l1:"
+                            id=":r2od:"
                             placeholder="Filter by Serial Number"
                             title="Filter by Serial Number"
                             type="text"
@@ -3595,7 +3595,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                         </div>
                         <p
                           class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-v98l45-MuiFormHelperText-root"
-                          id=":r2l1:-helper-text"
+                          id=":r2od:-helper-text"
                         >
                           <label>
                             Filter Mode: Fuzzy
@@ -3709,11 +3709,11 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd css-6h9cc6-MuiInputBase-root-MuiInput-root"
                           >
                             <input
-                              aria-describedby=":r2la:-helper-text"
+                              aria-describedby=":r2om:-helper-text"
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2la:"
+                              id=":r2om:"
                               inputmode="text"
                               placeholder="Min"
                               type="text"
@@ -3744,7 +3744,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                           </div>
                           <p
                             class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-18y2hez-MuiFormHelperText-root"
-                            id=":r2la:-helper-text"
+                            id=":r2om:-helper-text"
                           >
                             <label>
                               Filter Mode: Between Inclusive
@@ -3761,7 +3761,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2ld:"
+                              id=":r2op:"
                               inputmode="text"
                               placeholder="Max"
                               type="text"
@@ -3899,11 +3899,11 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd css-6h9cc6-MuiInputBase-root-MuiInput-root"
                           >
                             <input
-                              aria-describedby=":r2lk:-helper-text"
+                              aria-describedby=":r2p0:-helper-text"
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2lk:"
+                              id=":r2p0:"
                               inputmode="text"
                               placeholder="Min"
                               type="text"
@@ -3934,7 +3934,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                           </div>
                           <p
                             class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-18y2hez-MuiFormHelperText-root"
-                            id=":r2lk:-helper-text"
+                            id=":r2p0:-helper-text"
                           >
                             <label>
                               Filter Mode: Between Inclusive
@@ -3951,7 +3951,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2ln:"
+                              id=":r2p3:"
                               inputmode="text"
                               placeholder="Max"
                               type="text"
@@ -4089,11 +4089,11 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd css-6h9cc6-MuiInputBase-root-MuiInput-root"
                           >
                             <input
-                              aria-describedby=":r2lu:-helper-text"
+                              aria-describedby=":r2pa:-helper-text"
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2lu:"
+                              id=":r2pa:"
                               inputmode="text"
                               placeholder="Min"
                               type="text"
@@ -4124,7 +4124,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                           </div>
                           <p
                             class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-18y2hez-MuiFormHelperText-root"
-                            id=":r2lu:-helper-text"
+                            id=":r2pa:-helper-text"
                           >
                             <label>
                               Filter Mode: Between Inclusive
@@ -4141,7 +4141,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2m1:"
+                              id=":r2pd:"
                               inputmode="text"
                               placeholder="Max"
                               type="text"
@@ -4279,11 +4279,11 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd css-6h9cc6-MuiInputBase-root-MuiInput-root"
                           >
                             <input
-                              aria-describedby=":r2m8:-helper-text"
+                              aria-describedby=":r2pk:-helper-text"
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2m8:"
+                              id=":r2pk:"
                               inputmode="text"
                               placeholder="Min"
                               type="text"
@@ -4314,7 +4314,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                           </div>
                           <p
                             class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-18y2hez-MuiFormHelperText-root"
-                            id=":r2m8:-helper-text"
+                            id=":r2pk:-helper-text"
                           >
                             <label>
                               Filter Mode: Between Inclusive
@@ -4331,7 +4331,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2mb:"
+                              id=":r2pn:"
                               inputmode="text"
                               placeholder="Max"
                               type="text"
@@ -4469,9 +4469,9 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-label="Filter by Is Defective"
-                            aria-labelledby=":r2mi:"
+                            aria-labelledby=":r2pu:"
                             class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-10y8whu-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                            id=":r2mi:"
+                            id=":r2pu:"
                             role="combobox"
                             tabindex="0"
                           >
@@ -5122,7 +5122,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-10j3yc8-MuiFormLabel-root-MuiInputLabel-root"
-                  for="mrt-rows-per-page-:r2kq:"
+                  for="mrt-rows-per-page-:r2o6:"
                 >
                   Rows per page
                 </label>
@@ -5143,7 +5143,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                     aria-hidden="true"
                     aria-invalid="false"
                     class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
-                    id="mrt-rows-per-page-:r2kq:"
+                    id="mrt-rows-per-page-:r2o6:"
                     tabindex="-1"
                     value="5"
                   />

--- a/src/items/__snapshots__/itemsTable.component.test.tsx.snap
+++ b/src/items/__snapshots__/itemsTable.component.test.tsx.snap
@@ -13,38 +13,6 @@ exports[`Items Table > renders correctly part 1 due column virtualisation 1`] = 
         class="MuiBox-root css-1tbggly"
       >
         <div
-          class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
-          style="min-height: 0px;"
-        >
-          <div
-            class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
-          >
-            <div
-              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
-            >
-              <div
-                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-z99vq8-MuiPaper-root-MuiAlert-root"
-                role="alert"
-                style="--Paper-shadow: none;"
-              >
-                <div
-                  class="MuiAlert-message css-zioonp-MuiAlert-message"
-                >
-                  <div
-                    class="MuiStack-root css-5kul5x-MuiStack-root"
-                  >
-                    <div
-                      class="MuiBox-root css-k008qs"
-                    >
-                       
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
           class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
           style="opacity: 0; visibility: hidden;"
         >
@@ -248,7 +216,7 @@ exports[`Items Table > renders correctly part 1 due column virtualisation 1`] = 
         </div>
       </div>
       <div
-        class="MuiTableContainer-root css-1h4z99x-MuiTableContainer-root"
+        class="MuiTableContainer-root css-18mrzwk-MuiTableContainer-root"
         data-testid="items-table-container"
       >
         <table
@@ -1545,6 +1513,38 @@ exports[`Items Table > renders correctly part 1 due column virtualisation 1`] = 
         class="MuiBox-root css-10gei56"
       >
         <div
+          class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+          >
+            <div
+              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-z99vq8-MuiPaper-root-MuiAlert-root"
+                role="alert"
+                style="--Paper-shadow: none;"
+              >
+                <div
+                  class="MuiAlert-message css-zioonp-MuiAlert-message"
+                >
+                  <div
+                    class="MuiStack-root css-5kul5x-MuiStack-root"
+                  >
+                    <div
+                      class="MuiBox-root css-k008qs"
+                    >
+                       
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="MuiBox-root css-1llu0od"
         >
           <p
@@ -1684,38 +1684,6 @@ exports[`Items Table > renders correctly part 2 due column virtualisation 1`] = 
       <div
         class="MuiBox-root css-1tbggly"
       >
-        <div
-          class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
-          style="min-height: 0px;"
-        >
-          <div
-            class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
-          >
-            <div
-              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
-            >
-              <div
-                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-z99vq8-MuiPaper-root-MuiAlert-root"
-                role="alert"
-                style="--Paper-shadow: none;"
-              >
-                <div
-                  class="MuiAlert-message css-zioonp-MuiAlert-message"
-                >
-                  <div
-                    class="MuiStack-root css-5kul5x-MuiStack-root"
-                  >
-                    <div
-                      class="MuiBox-root css-k008qs"
-                    >
-                       
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
         <div
           class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
           style="opacity: 0; visibility: hidden;"
@@ -1923,7 +1891,7 @@ exports[`Items Table > renders correctly part 2 due column virtualisation 1`] = 
         </div>
       </div>
       <div
-        class="MuiTableContainer-root css-1h4z99x-MuiTableContainer-root"
+        class="MuiTableContainer-root css-18mrzwk-MuiTableContainer-root"
         data-testid="items-table-container"
       >
         <table
@@ -3216,6 +3184,38 @@ exports[`Items Table > renders correctly part 2 due column virtualisation 1`] = 
         class="MuiBox-root css-10gei56"
       >
         <div
+          class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+          >
+            <div
+              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-z99vq8-MuiPaper-root-MuiAlert-root"
+                role="alert"
+                style="--Paper-shadow: none;"
+              >
+                <div
+                  class="MuiAlert-message css-zioonp-MuiAlert-message"
+                >
+                  <div
+                    class="MuiStack-root css-5kul5x-MuiStack-root"
+                  >
+                    <div
+                      class="MuiBox-root css-k008qs"
+                    >
+                       
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="MuiBox-root css-1llu0od"
         >
           <p
@@ -3552,12 +3552,12 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             </span>
                           </div>
                           <input
-                            aria-describedby=":r2mp:-helper-text"
+                            aria-describedby=":r2l1:-helper-text"
                             aria-invalid="false"
                             aria-label="Filter by Serial Number"
                             autocomplete="off"
                             class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-110vr2a-MuiInputBase-input-MuiInput-input"
-                            id=":r2mp:"
+                            id=":r2l1:"
                             placeholder="Filter by Serial Number"
                             title="Filter by Serial Number"
                             type="text"
@@ -3595,7 +3595,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                         </div>
                         <p
                           class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-v98l45-MuiFormHelperText-root"
-                          id=":r2mp:-helper-text"
+                          id=":r2l1:-helper-text"
                         >
                           <label>
                             Filter Mode: Fuzzy
@@ -3709,11 +3709,11 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd css-6h9cc6-MuiInputBase-root-MuiInput-root"
                           >
                             <input
-                              aria-describedby=":r2n2:-helper-text"
+                              aria-describedby=":r2la:-helper-text"
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2n2:"
+                              id=":r2la:"
                               inputmode="text"
                               placeholder="Min"
                               type="text"
@@ -3744,7 +3744,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                           </div>
                           <p
                             class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-18y2hez-MuiFormHelperText-root"
-                            id=":r2n2:-helper-text"
+                            id=":r2la:-helper-text"
                           >
                             <label>
                               Filter Mode: Between Inclusive
@@ -3761,7 +3761,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2n5:"
+                              id=":r2ld:"
                               inputmode="text"
                               placeholder="Max"
                               type="text"
@@ -3899,11 +3899,11 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd css-6h9cc6-MuiInputBase-root-MuiInput-root"
                           >
                             <input
-                              aria-describedby=":r2nc:-helper-text"
+                              aria-describedby=":r2lk:-helper-text"
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2nc:"
+                              id=":r2lk:"
                               inputmode="text"
                               placeholder="Min"
                               type="text"
@@ -3934,7 +3934,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                           </div>
                           <p
                             class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-18y2hez-MuiFormHelperText-root"
-                            id=":r2nc:-helper-text"
+                            id=":r2lk:-helper-text"
                           >
                             <label>
                               Filter Mode: Between Inclusive
@@ -3951,7 +3951,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2nf:"
+                              id=":r2ln:"
                               inputmode="text"
                               placeholder="Max"
                               type="text"
@@ -4089,11 +4089,11 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd css-6h9cc6-MuiInputBase-root-MuiInput-root"
                           >
                             <input
-                              aria-describedby=":r2nm:-helper-text"
+                              aria-describedby=":r2lu:-helper-text"
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2nm:"
+                              id=":r2lu:"
                               inputmode="text"
                               placeholder="Min"
                               type="text"
@@ -4124,7 +4124,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                           </div>
                           <p
                             class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-18y2hez-MuiFormHelperText-root"
-                            id=":r2nm:-helper-text"
+                            id=":r2lu:-helper-text"
                           >
                             <label>
                               Filter Mode: Between Inclusive
@@ -4141,7 +4141,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2np:"
+                              id=":r2m1:"
                               inputmode="text"
                               placeholder="Max"
                               type="text"
@@ -4279,11 +4279,11 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd css-6h9cc6-MuiInputBase-root-MuiInput-root"
                           >
                             <input
-                              aria-describedby=":r2o0:-helper-text"
+                              aria-describedby=":r2m8:-helper-text"
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2o0:"
+                              id=":r2m8:"
                               inputmode="text"
                               placeholder="Min"
                               type="text"
@@ -4314,7 +4314,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                           </div>
                           <p
                             class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-18y2hez-MuiFormHelperText-root"
-                            id=":r2o0:-helper-text"
+                            id=":r2m8:-helper-text"
                           >
                             <label>
                               Filter Mode: Between Inclusive
@@ -4331,7 +4331,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                               aria-invalid="false"
                               autocomplete="off"
                               class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-1yrc8ca-MuiInputBase-input-MuiInput-input"
-                              id=":r2o3:"
+                              id=":r2mb:"
                               inputmode="text"
                               placeholder="Max"
                               type="text"
@@ -4469,9 +4469,9 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-label="Filter by Is Defective"
-                            aria-labelledby=":r2oa:"
+                            aria-labelledby=":r2mi:"
                             class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd css-10y8whu-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                            id=":r2oa:"
+                            id=":r2mi:"
                             role="combobox"
                             tabindex="0"
                           >
@@ -5072,6 +5072,38 @@ exports[`Items Table > renders the dense table correctly 1`] = `
         class="MuiBox-root css-10gei56"
       >
         <div
+          class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+          >
+            <div
+              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-z99vq8-MuiPaper-root-MuiAlert-root"
+                role="alert"
+                style="--Paper-shadow: none;"
+              >
+                <div
+                  class="MuiAlert-message css-zioonp-MuiAlert-message"
+                >
+                  <div
+                    class="MuiStack-root css-5kul5x-MuiStack-root"
+                  >
+                    <div
+                      class="MuiBox-root css-k008qs"
+                    >
+                       
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="MuiBox-root css-1llu0od"
         >
           <p
@@ -5090,7 +5122,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-10j3yc8-MuiFormLabel-root-MuiInputLabel-root"
-                  for="mrt-rows-per-page-:r2mi:"
+                  for="mrt-rows-per-page-:r2kq:"
                 >
                   Rows per page
                 </label>
@@ -5111,7 +5143,7 @@ exports[`Items Table > renders the dense table correctly 1`] = `
                     aria-hidden="true"
                     aria-invalid="false"
                     class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
-                    id="mrt-rows-per-page-:r2mi:"
+                    id="mrt-rows-per-page-:r2kq:"
                     tabindex="-1"
                     value="5"
                   />

--- a/src/items/itemsTable.component.test.tsx
+++ b/src/items/itemsTable.component.test.tsx
@@ -255,6 +255,65 @@ describe('Items Table', () => {
     });
   });
 
+  it('sets the spares definition filter and checks the banner is still visible when grouped and then clears the table filters', async () => {
+    props.catalogueCategory = getCatalogueCategoryById(
+      '9'
+    ) as CatalogueCategory;
+    props.catalogueItem = getCatalogueItemById('11') as CatalogueItem;
+    createView();
+
+    await waitFor(() => {
+      expect(screen.getByText('Serial Number')).toBeInTheDocument();
+    });
+    const showSparesButton = screen.getByRole('button', {
+      name: 'Show Spare Items',
+    });
+    expect(showSparesButton).not.toBeDisabled();
+
+    await user.click(showSparesButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText('tenrMn1KOmIg')).not.toBeInTheDocument();
+    });
+
+    expect(
+      await screen.findByText('Spares Definition Filter Applied')
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByLabelText(
+        'Items that are contained within this system type Storage are classified as spares'
+      )
+    ).toBeInTheDocument();
+
+    // Delivered date column action button
+    await user.click(
+      screen.getAllByRole('button', { name: 'Column Actions' })[3]
+    );
+
+    await user.click(await screen.findByText('Group by Asset Number'));
+
+    expect(
+      await screen.findByText('Spares Definition Filter Applied')
+    ).toBeInTheDocument();
+
+    const clearFiltersButton = screen.getByRole('button', {
+      name: 'Clear Filters',
+    });
+
+    await user.click(clearFiltersButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Spares Definition Filter Applied')
+      ).not.toBeInTheDocument();
+    });
+
+    expect(
+      await screen.findByText('DEAbxBGr2M', { exact: false })
+    ).toBeInTheDocument();
+  });
+
   it('sets the spares definition filter and clears the spares filters (multiples systems types in spares definition)', async () => {
     server.use(
       http.get<PathParams, DefaultBodyType, SparesDefinition>(

--- a/src/items/itemsTable.component.tsx
+++ b/src/items/itemsTable.component.tsx
@@ -4,6 +4,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import SaveAsIcon from '@mui/icons-material/SaveAs';
 import {
+  Alert,
   Box,
   Button,
   IconButton,
@@ -23,7 +24,7 @@ import {
 } from 'material-react-table';
 import { MRT_Localization_EN } from 'material-react-table/locales/en';
 import React from 'react';
-import { Link, useSearchParams } from 'react-router';
+import { Link } from 'react-router';
 import {
   CatalogueCategory,
   CatalogueItem,
@@ -49,6 +50,7 @@ import {
   MRT_Functions_Localisation,
   mrtTheme,
   OPTIONAL_FILTER_MODE_OPTIONS,
+  sortDataList,
   TableBodyCellOverFlowTip,
   TableCellOverFlowTipProps,
   TableGroupedCell,
@@ -74,8 +76,6 @@ interface TableRowData {
 export function ItemsTable(props: ItemTableProps) {
   const { catalogueCategory, catalogueItem, dense } = props;
 
-  const [searchParams, setSearchParams] = useSearchParams();
-
   const [tableRows, setTableRows] = React.useState<TableRowData[]>([]);
 
   const noResultsText =
@@ -99,9 +99,9 @@ export function ItemsTable(props: ItemTableProps) {
     useGetUsageStatuses();
 
   const {
-    encodedSparesFilter,
     isLoading: isLoadingSparesDefinition,
     sparesDefinition,
+    sparesColumnsFilters,
   } = useSparesFilterState();
 
   const isSparesDefinitionDefined =
@@ -450,6 +450,26 @@ export function ItemsTable(props: ItemTableProps) {
     storeInUrl: !dense,
   });
 
+  const isSparesFilterApplied = React.useMemo(() => {
+    if (sparesDefinition === '') return false;
+    if (preservedState.columnFilters.length !== 1) return false;
+    if (preservedState.columnFilters[0].id !== 'system.type.value')
+      return false;
+    const orderedColumnFilterValues = sortDataList(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      preservedState.columnFilters[0].value as any[]
+    );
+    const sparesSystemTypeValues = sparesDefinition.system_types.map(
+      (type) => type.value
+    );
+    const orderedSparesDefinitionValues = sortDataList(sparesSystemTypeValues);
+
+    return (
+      JSON.stringify(orderedColumnFilterValues) ===
+      JSON.stringify(orderedSparesDefinitionValues)
+    );
+  }, [preservedState, sparesDefinition]);
+
   const table = useMaterialReactTable({
     // Data
     columns: dense
@@ -488,7 +508,7 @@ export function ItemsTable(props: ItemTableProps) {
         },
     manualFiltering: false,
     paginationDisplayMode: 'pages',
-    positionToolbarAlertBanner: 'top',
+    positionToolbarAlertBanner: 'bottom',
     autoResetPageIndex: false,
     displayColumnDefOptions: dense
       ? undefined
@@ -535,7 +555,7 @@ export function ItemsTable(props: ItemTableProps) {
           height: dense
             ? '360.4px'
             : getPageHeightCalc(
-                `50px + 110px + 48px ${showAlert ? '+ 54px' : ''}`
+                `50px + 110px + 48px ${showAlert ? '+ 64px' : ''} ${isSparesFilterApplied ? ' + 54px' : ''}`
               ),
           flexShrink: 1,
         },
@@ -640,11 +660,15 @@ export function ItemsTable(props: ItemTableProps) {
           <Button
             sx={{ mx: 0.5 }}
             variant="outlined"
-            disabled={searchParams.get('state') === encodedSparesFilter}
+            disabled={isSparesFilterApplied}
             onClick={() => {
-              const newParams = new URLSearchParams(searchParams);
-              newParams.set('state', encodedSparesFilter);
-              setSearchParams(newParams, { replace: false });
+              onPreservedStatesChange.onColumnFiltersChange(
+                sparesColumnsFilters.cF.map((filter) => ({
+                  id: filter.id,
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  value: (filter.value as any[]).map((val) => val.value),
+                }))
+              );
             }}
           >
             Show Spare Items
@@ -701,47 +725,6 @@ export function ItemsTable(props: ItemTableProps) {
         </MenuItem>,
       ];
     },
-    renderToolbarAlertBannerContent:
-      isSparesDefinitionDefined &&
-      searchParams.get('state') === encodedSparesFilter
-        ? ({ table }) => (
-            <Grid container alignItems="center" sx={{ px: 1, py: 0.5 }}>
-              <Grid size={2}> </Grid>
-              <Grid size={8}>
-                <Box display="flex" alignItems="center" justifyContent="center">
-                  <Typography variant="inherit" sx={{ pr: 1 }}>
-                    Spares Definition Filter Applied
-                  </Typography>
-                  <Tooltip
-                    title={`Items that are contained within ${
-                      sparesDefinition.system_types.length === 1
-                        ? 'this system type'
-                        : 'these system types'
-                    } ${sparesDefinition.system_types
-                      .map((sys) => sys.value)
-                      .join(', ')} are classified as spares`}
-                  >
-                    <InfoOutlined fontSize="small" />
-                  </Tooltip>
-                </Box>
-              </Grid>
-              <Grid size={2} display="flex" justifyContent="flex-end">
-                <Tooltip title="Clear Spares Definition Filter">
-                  <span>
-                    <IconButton
-                      size="small"
-                      aria-label="Clear Spares Definition Filter"
-                      onClick={() => table.resetColumnFilters()}
-                      sx={{ color: 'inherit' }}
-                    >
-                      <ClearIcon fontSize="small" />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              </Grid>
-            </Grid>
-          )
-        : undefined,
     renderBottomToolbarCustomActions: ({ table }) =>
       displayTableRowCountText(table, itemsData, 'Items', {
         paddingLeft: '8px',
@@ -756,15 +739,64 @@ export function ItemsTable(props: ItemTableProps) {
       : undefined,
   });
 
-  React.useEffect(() => {
-    if (isSparesDefinitionDefined)
-      table.setShowAlertBanner(
-        searchParams.get('state') === encodedSparesFilter
-      );
-  }, [encodedSparesFilter, isSparesDefinitionDefined, searchParams, table]);
-
   return (
     <div style={{ width: '100%' }}>
+      {isSparesDefinitionDefined && isSparesFilterApplied && (
+        <Alert
+          color="info"
+          icon={false}
+          sx={() => ({
+            '& .MuiAlert-message': {
+              width: '100%',
+            },
+            borderRadius: 0,
+            fontSize: '1rem',
+            left: 0,
+            p: 0,
+            position: 'relative',
+            right: 0,
+            top: 0,
+            width: '100%',
+            zIndex: 2,
+          })}
+        >
+          <Grid container alignItems="center" sx={{ px: 1, py: 0.5 }}>
+            <Grid size={2}> </Grid>
+            <Grid size={8}>
+              <Box display="flex" alignItems="center" justifyContent="center">
+                <Typography variant="inherit" sx={{ pr: 1 }}>
+                  Spares Definition Filter Applied
+                </Typography>
+                <Tooltip
+                  title={`Items that are contained within ${
+                    sparesDefinition.system_types.length === 1
+                      ? 'this system type'
+                      : 'these system types'
+                  } ${sparesDefinition.system_types
+                    .map((sys) => sys.value)
+                    .join(', ')} are classified as spares`}
+                >
+                  <InfoOutlined fontSize="small" />
+                </Tooltip>
+              </Box>
+            </Grid>
+            <Grid size={2} display="flex" justifyContent="flex-end">
+              <Tooltip title="Clear Spares Definition Filter">
+                <span>
+                  <IconButton
+                    size="small"
+                    aria-label="Clear Spares Definition Filter"
+                    onClick={() => table.resetColumnFilters()}
+                    sx={{ color: 'inherit' }}
+                  >
+                    <ClearIcon fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Grid>
+          </Grid>
+        </Alert>
+      )}
       <MaterialReactTable table={table} />
       {!dense && selectedItem && (
         <DeleteItemDialog

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -390,8 +390,12 @@ export const resetUniqueIdCounter = () => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function sortDataList(data: any[], sortedValue: string) {
-  return data.sort((a, b) => a[sortedValue].localeCompare(b[sortedValue]));
+export function sortDataList(data: any[], sortedValue?: string) {
+  return data.sort((a, b) => {
+    const valueA = sortedValue ? a[sortedValue] : a;
+    const valueB = sortedValue ? b[sortedValue] : b;
+    return valueA.localeCompare(valueB);
+  });
 }
 
 export const displayTableRowCountText = <TData extends MRT_RowData>(
@@ -600,7 +604,7 @@ export const useSparesFilterState = (
 ): {
   sparesDefinition: '' | SparesDefinition;
   sparesFilterState: string;
-  encodedSparesFilter: string;
+  sparesColumnsFilters: { cF: MRT_ColumnFiltersState };
   isLoading: boolean;
 } => {
   const {
@@ -629,7 +633,7 @@ export const useSparesFilterState = (
 
   return {
     sparesFilterState,
-    encodedSparesFilter,
+    sparesColumnsFilters,
     isLoading: isLoadingSparesDefinition,
     sparesDefinition,
   };


### PR DESCRIPTION
## Description

Create a separate banner for spares, as the bottom banner was need for grouped by columns 
The spares banner wasn't applied when non columns filter state value were modified such as pagination and grouping. It should be visible e.g. page 2 or group by assets number   

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes #1588
