### PR TITLE
Update httpd image to 2.4.65-alpine3.22

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -30,11 +30,11 @@ RUN set -eux; \
     yarn build;
 
 # Run stage
-FROM httpd:2.4.63-alpine3.21@sha256:4aec2953509e2d3aa5a8d73c580a381be44803fd2481875b15d9ad7d2810d7ca
+FROM httpd:2.4.65-alpine3.22@sha256:07b2fabb7029a0b8aeb2e0fd02651c28fe22c21c5b5a59d6ff5b022791fcd89e
 
 # Install specific version of jq (Used for assigning config values in entrypoint script)
 # Reference: https://pkgs.alpinelinux.org/package/edge/main/x86/jq
-RUN apk add --no-cache jq=1.7.1-r0
+RUN apk add --no-cache jq=1.8.1-r0
 
 WORKDIR /usr/local/apache2/htdocs
 


### PR DESCRIPTION
## Description

Updates the httpd image used, renovate is still missing it for some reason. Was last done in https://github.com/ral-facilities/inventory-management-system/pull/1313. jq also had to be updated as the previous version didn't exist in the new alpine image.

Not vital for demo so no hurry.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
