### PR TITLE
Use 401 instead of 403 for token refreshing #1644

### DIFF
--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -7,7 +7,7 @@ import { parseErrorResponse } from '../utils';
 import { APIError } from './api.types';
 
 // These are for ensuring refresh request is only sent once when multiple requests
-// are failing due to 403's at the same time
+// are failing due to 401's at the same time
 let isFetchingAccessToken = false;
 let failedAuthRequestQueue: ((shouldReject?: boolean) => void)[] = [];
 
@@ -53,7 +53,7 @@ const createAuthenticatedClient = (props: {
       // only allow a request to be retried once. Don't retry if not logged
       // in, it should not have been accessible
       if (
-        error.response?.status === 403 &&
+        error.response?.status === 401 &&
         errorMessage.includes('expired token') &&
         !originalRequest._retried &&
         localStorage.getItem('scigateway:token')
@@ -100,7 +100,7 @@ export function uppyOnAfterResponse(xhr: XMLHttpRequest) {
 
     // Check if the token is invalid and needs refreshing
     if (
-      xhr.status === 403 &&
+      xhr.status === 401 &&
       errorMessage.includes('expired token') &&
       localStorage.getItem('scigateway:token')
     ) {

--- a/src/handleIMS_APIError.test.ts
+++ b/src/handleIMS_APIError.test.ts
@@ -54,12 +54,12 @@ describe('handleIMS_APIError', () => {
     });
   });
 
-  it('does not broadcast 403 errors', () => {
+  it('does not broadcast 401 errors', () => {
     error = {
       isAxiosError: true,
       response: {
         data: {},
-        status: 403,
+        status: 401,
         statusText: 'Invalid token or expired token',
         headers: {},
         // @ts-expect-error: not needed for test

--- a/src/handleIMS_APIError.ts
+++ b/src/handleIMS_APIError.ts
@@ -17,7 +17,7 @@ const handleIMS_APIError = (error: AxiosError, broadcast = true): void => {
   // due to the plugin its routing from being different). It is assumed that errors of this nature
   // should not be possible due to SciGateway verifying the user itself, so we follow DataGateway's
   // approach and don't display any of these errors.
-  if (broadcast && status !== 403) {
+  if (broadcast && status !== 401) {
     let broadcastMessage;
     if (!error.response)
       // No response so it's a network error

--- a/src/retryIMS_APIErrors.test.ts
+++ b/src/retryIMS_APIErrors.test.ts
@@ -21,9 +21,9 @@ describe('retryIMS_APIErrors', () => {
     };
   });
 
-  it('returns false if error code is 403', () => {
+  it('returns false if error code is 401', () => {
     if (error.response) {
-      error.response.status = 403;
+      error.response.status = 401;
     }
     const result = retryIMS_APIErrors(0, error);
     expect(result).toBe(false);

--- a/src/retryIMS_APIErrors.ts
+++ b/src/retryIMS_APIErrors.ts
@@ -4,7 +4,7 @@ const retryIMS_APIErrors = (
   failureCount: number,
   error: AxiosError
 ): boolean => {
-  if (error.response?.status === 403 || failureCount >= 3) return false;
+  if (error.response?.status === 401 || failureCount >= 3) return false;
   return true;
 };
 


### PR DESCRIPTION
## Description

As a consequence also resolves https://github.com/ral-facilities/inventory-management-system/issues/1622. 
E.g. <img width="682" height="622" alt="image" src="https://github.com/user-attachments/assets/3182e323-6975-46f8-a5d3-95810ef8aa3e" />
(This is shown when as an admin opening add unit then removing my admin role before waiting to click save so it refreshes when it does the post)


I verified the token refreshing didnt work before the change and now does. Tested with https://github.com/ral-facilities/ldap-jwt-auth/pull/330, https://github.com/ral-facilities/inventory-management-system-api/pull/713 & https://github.com/ral-facilities/object-storage-api/pull/265.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #1644, Closes #1622
