### PR TITLE
Update eslint-plugin-react-hooks to 7.0.1 and use shareable config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,16 @@ import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
+  eslint.configs.recommended,
+  tseslint.configs.recommended,
+  cypressPlugin.configs.recommended,
+  reactPlugin.configs.flat.recommended,
+  reactPlugin.configs.flat['jsx-runtime'],
+  reactHooksPlugin.configs.flat.recommended,
+  queryPlugin.configs['flat/recommended'],
+  jsxA11yPlugin.flatConfigs.recommended,
+  // See https://github.com/prettier/eslint-config-prettier put last
+  prettierPlugin,
   {
     files: ['**/*.{js,ts,jsx,tsx}'],
     languageOptions: {
@@ -32,19 +42,8 @@ export default defineConfig(
       },
     },
     plugins: {
-      react: reactPlugin,
-      '@tanstack/query': queryPlugin,
       'no-only-tests': noOnlyTestsPlugin,
-      'jsx-a11y': jsxA11yPlugin,
     },
-    extends: [
-      eslint.configs.recommended,
-      ...tseslint.configs.recommended,
-      reactHooksPlugin.configs['recommended-latest'],
-      cypressPlugin.configs.recommended,
-      // See https://github.com/prettier/eslint-config-prettier put last
-      prettierPlugin,
-    ],
     rules: {
       // Emulate typescript style for unused variables, see
       // https://typescript-eslint.io/rules/no-unused-vars/
@@ -60,13 +59,13 @@ export default defineConfig(
           ignoreRestSiblings: true,
         },
       ],
-      ...reactPlugin.configs.recommended.rules,
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',
-      ...reactHooksPlugin.configs.recommended.rules,
-      ...queryPlugin.configs.recommended.rules,
       'no-only-tests/no-only-tests': 'error',
-      ...jsxA11yPlugin.configs.recommended.rules,
+      // Current version of react hook form gives "warning  Compilation Skipped: Use of incompatible library"
+      'react-hooks/incompatible-library': 'off',
+      // Current usage of uppy violates this rule
+      'react-hooks/refs': 'off',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "eslint-plugin-no-only-tests": "3.3.0",
     "eslint-plugin-prettier": "5.5.5",
     "eslint-plugin-react": "7.37.5",
-    "eslint-plugin-react-hooks": "5.2.0",
+    "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-testing-library": "7.15.4",
     "express": "5.2.1",
     "globals": "17.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -250,6 +250,7 @@ if (!isUsingMSW) router = createBrowserRouter(routeObject);
 // environment, this is not needed.
 
 export default function App() {
+  // eslint-disable-next-line react-hooks/globals
   if (isUsingMSW) router = createBrowserRouter(routeObject);
   return <RouterProvider router={router} />;
 }

--- a/src/catalogue/items/catalogueItemDirectoryDialog.component.tsx
+++ b/src/catalogue/items/catalogueItemDirectoryDialog.component.tsx
@@ -53,6 +53,10 @@ const CatalogueItemDirectoryDialog = (
   const [parentCategoryId, setParentCategoryId] = React.useState<string | null>(
     props.parentCategoryId
   );
+  const [errorMessage, setErrorMessage] = React.useState<string | undefined>(
+    undefined
+  );
+
   React.useEffect(() => {
     setParentCategoryId(props.parentCategoryId);
   }, [props.parentCategoryId]);
@@ -83,10 +87,6 @@ const CatalogueItemDirectoryDialog = (
 
   const { data: targetCatalogueCategory } =
     useGetCatalogueCategory(parentCategoryId);
-
-  const [errorMessage, setErrorMessage] = React.useState<string | undefined>(
-    undefined
-  );
 
   const handleMoveToCatalogueItem = React.useCallback(() => {
     if (

--- a/src/systems/systemItemsDialog.component.tsx
+++ b/src/systems/systemItemsDialog.component.tsx
@@ -47,8 +47,10 @@ export interface UsageStatusesType {
   usage_status_id: string;
 }
 
-export interface UsageStatusesErrorType
-  extends Omit<UsageStatusesType, 'usageStatus'> {
+export interface UsageStatusesErrorType extends Omit<
+  UsageStatusesType,
+  'usageStatus'
+> {
   error: boolean;
 }
 
@@ -132,6 +134,10 @@ const SystemItemsDialog = React.memo((props: SystemItemsDialogProps) => {
   const { mutateAsync: moveItemsToSystem, isPending: isMovePending } =
     useMoveItemsToSystem();
 
+  // Stepper
+  const STEPS = ['Place into a system', 'Confirm usage statuses'];
+  const [activeStep, setActiveStep] = React.useState<number>(0);
+
   const populateUsageStatuses = React.useCallback(() => {
     const usageStatusId =
       srcSystemTypeId === dstSystemTypeId || selectedRules?.length === 0
@@ -164,7 +170,7 @@ const SystemItemsDialog = React.memo((props: SystemItemsDialogProps) => {
     setActiveStep(0);
     setParentSystemId(props.parentSystemId);
     onClose();
-  }, [onClose, props.parentSystemId]);
+  }, [onClose, props.parentSystemId, setActiveStep]);
 
   const hasSystemErrors =
     // Disable when not moving anywhere different
@@ -228,10 +234,6 @@ const SystemItemsDialog = React.memo((props: SystemItemsDialogProps) => {
     handleClose,
   ]);
 
-  // Stepper
-  const STEPS = ['Place into a system', 'Confirm usage statuses'];
-  const [activeStep, setActiveStep] = React.useState<number>(0);
-
   const handleNext = React.useCallback(
     (step: number) => {
       switch (step) {
@@ -250,7 +252,7 @@ const SystemItemsDialog = React.memo((props: SystemItemsDialogProps) => {
         }
       }
     },
-    [hasSystemErrors, populateUsageStatuses]
+    [hasSystemErrors, populateUsageStatuses, setActiveStep]
   );
 
   const handleBack = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,7 +91,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.29.0":
+"@babel/core@npm:^7.24.4, @babel/core@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/core@npm:7.29.0"
   dependencies:
@@ -208,7 +208,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.28.5, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.28.5, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/parser@npm:7.29.0"
   dependencies:
@@ -4651,12 +4651,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:5.2.0":
-  version: 5.2.0
-  resolution: "eslint-plugin-react-hooks@npm:5.2.0"
+"eslint-plugin-react-hooks@npm:7.0.1":
+  version: 7.0.1
+  resolution: "eslint-plugin-react-hooks@npm:7.0.1"
+  dependencies:
+    "@babel/core": "npm:^7.24.4"
+    "@babel/parser": "npm:^7.24.4"
+    hermes-parser: "npm:^0.25.1"
+    zod: "npm:^3.25.0 || ^4.0.0"
+    zod-validation-error: "npm:^3.5.0 || ^4.0.0"
   peerDependencies:
     eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-  checksum: 10c0/1c8d50fa5984c6dea32470651807d2922cc3934cf3425e78f84a24c2dfd972e7f019bee84aefb27e0cf2c13fea0ac1d4473267727408feeb1c56333ca1489385
+  checksum: 10c0/1e711d1a9d1fa9cfc51fa1572500656577201199c70c795c6a27adfc1df39e5c598f69aab6aa91117753d23cc1f11388579a2bed14921cf9a4efe60ae8618496
   languageName: node
   linkType: hard
 
@@ -5506,6 +5512,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hermes-estree@npm:0.25.1":
+  version: 0.25.1
+  resolution: "hermes-estree@npm:0.25.1"
+  checksum: 10c0/48be3b2fa37a0cbc77a112a89096fa212f25d06de92781b163d67853d210a8a5c3784fac23d7d48335058f7ed283115c87b4332c2a2abaaccc76d0ead1a282ac
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:^0.25.1":
+  version: 0.25.1
+  resolution: "hermes-parser@npm:0.25.1"
+  dependencies:
+    hermes-estree: "npm:0.25.1"
+  checksum: 10c0/3abaa4c6f1bcc25273f267297a89a4904963ea29af19b8e4f6eabe04f1c2c7e9abd7bfc4730ddb1d58f2ea04b6fee74053d8bddb5656ec6ebf6c79cc8d14202c
+  languageName: node
+  linkType: hard
+
 "highlight-words@npm:2.0.0":
   version: 2.0.0
   resolution: "highlight-words@npm:2.0.0"
@@ -5766,7 +5788,7 @@ __metadata:
     eslint-plugin-no-only-tests: "npm:3.3.0"
     eslint-plugin-prettier: "npm:5.5.5"
     eslint-plugin-react: "npm:7.37.5"
-    eslint-plugin-react-hooks: "npm:5.2.0"
+    eslint-plugin-react-hooks: "npm:7.0.1"
     eslint-plugin-testing-library: "npm:7.15.4"
     express: "npm:5.2.1"
     globals: "npm:17.3.0"
@@ -9667,9 +9689,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod-validation-error@npm:^3.5.0 || ^4.0.0":
+  version: 4.0.2
+  resolution: "zod-validation-error@npm:4.0.2"
+  peerDependencies:
+    zod: ^3.25.0 || ^4.0.0
+  checksum: 10c0/0ccfec48c46de1be440b719cd02044d4abb89ed0e14c13e637cd55bf29102f67ccdba373f25def0fc7130e5f15025be4d557a7edcc95d5a3811599aade689e1b
+  languageName: node
+  linkType: hard
+
 "zod@npm:^3.22.4, zod@npm:^3.25.0":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.0 || ^4.0.0":
+  version: 4.3.6
+  resolution: "zod@npm:4.3.6"
+  checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Description

Did while reviewing https://github.com/ral-facilities/datagateway/pull/1878. There is alot more shareble config now so used here like Louise did. Also updates react hooks plugin as it was required for one of these (and is for some reason lumped into the React 19 monorepo update by renovate, when its backwards compatible).

There were two rules I had to disable as I cant see a quick fix for them as they are releated to react hook form & uppy usage, both of which have other updates. Other minor changes were one or two missing dependencies, and some state setters that were used prior to the useState which had to be reordered.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
