### PR TITLE
Fix missing imsJsApiUrl when running prod docker image

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,6 +16,7 @@ jq \
   --arg pluginHost "$PLUGIN_HOST" \
   '.imsApiUrl = $imsApiUrl |
    .osApiUrl = $osApiUrl |
+   .imsJsApiUrl = $imsJsApiUrl |
    .maxAttachmentSizeBytes = $maxAttachmentSizeBytes |
    .attachmentAllowedFileExtensions = $attachmentAllowedFileExtensions |
    .imageAllowedFileExtensions = $imageAllowedFileExtensions |


### PR DESCRIPTION
## Description

See title. Have checked with deployment changes that this fixes the issue.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

