### PR TITLE
fix: fallback to first image when no primary image is set

### DIFF
--- a/src/api/images.tsx
+++ b/src/api/images.tsx
@@ -49,12 +49,13 @@ const getImages = async (
 
 export const useGetImages = (
   entityId?: string,
-  primary?: boolean
+  primary?: boolean,
+  enabled = true
 ): UseQueryResult<APIImage[], AxiosError> => {
   return useQuery({
     queryKey: ['Images', entityId, primary],
     queryFn: () => getImages(entityId ?? '', primary),
-    enabled: !!entityId,
+    enabled: !!entityId && enabled,
   });
 };
 

--- a/src/common/images/primaryImage.component.test.tsx
+++ b/src/common/images/primaryImage.component.test.tsx
@@ -91,9 +91,16 @@ describe('PrimaryImage Component', () => {
     });
   });
 
-  it('Removes the remove primary image button when there is no set primary image', async () => {
+  it('falls back to the first available image when there is no set primary image', async () => {
     props.entityId = '90';
     createView();
+
+    await waitFor(() => {
+      expect(screen.getByRole('img')).toHaveAttribute(
+        'src',
+        expect.stringContaining('UklGRmYUAAB')
+      );
+    });
 
     const actionButton = screen.getByLabelText('primary images action menu');
     await user.click(actionButton);

--- a/src/common/images/primaryImage.component.tsx
+++ b/src/common/images/primaryImage.component.tsx
@@ -86,23 +86,30 @@ export interface PrimaryImageProps {
 const PrimaryImage = (props: PrimaryImageProps) => {
   const { entityId, isDetailsPanel = false } = props;
 
-  const { data: imagesData, isLoading: imageLoading } = useGetImages(
-    entityId,
-    true
-  );
+  const { data: primaryImagesData, isLoading: primaryImageLoading } =
+    useGetImages(entityId, true);
 
-  const primaryImageExists = !!imagesData && imagesData.length > 0;
+  const primaryImageExists =
+    !!primaryImagesData && primaryImagesData.length > 0;
+
+  const useFallbackImage = !primaryImageLoading && !primaryImageExists;
+  const { data: fallbackImagesData, isLoading: fallbackImageLoading } =
+    useGetImages(entityId, undefined, useFallbackImage);
+
+  const imageData = primaryImagesData?.[0] ?? fallbackImagesData?.[0];
+  const imageLoading =
+    primaryImageLoading || (useFallbackImage && fallbackImageLoading);
 
   const [searchParams, setSearchParams] = useSearchParams();
 
   const handleViewPrimary = React.useCallback(() => {
-    if (imagesData?.[0]) {
+    if (imageData) {
       const updatedParams = new URLSearchParams(searchParams);
       updatedParams.set('tab', 'Gallery');
-      updatedParams.set('image', imagesData?.[0].id);
+      updatedParams.set('image', imageData.id);
       setSearchParams(updatedParams);
     }
-  }, [searchParams, setSearchParams, imagesData]);
+  }, [searchParams, setSearchParams, imageData]);
 
   const [primaryDialogOpen, setPrimaryDialogOpen] = React.useState<
     false | 'set' | 'remove'
@@ -111,7 +118,7 @@ const PrimaryImage = (props: PrimaryImageProps) => {
   return (
     <>
       <ThumbnailImage
-        image={imagesData?.[0]}
+        image={imageData}
         dense={isDetailsPanel}
         isPrimaryThumbnail
         imageLoading={imageLoading}
@@ -138,7 +145,7 @@ const PrimaryImage = (props: PrimaryImageProps) => {
               onClose={() => {
                 setPrimaryDialogOpen(false);
               }}
-              image={imagesData[0]}
+              image={primaryImagesData[0]}
             />
           )}
         </>


### PR DESCRIPTION
## Description

Adds fallback behaviour for the primary image display so that, when no primary image exists, the first available image is shown instead. The remove-primary action remains hidden unless an actual primary image is set.

Fixes #1805

## Testing instructions

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Run `NODE_OPTIONS='--localstorage-file=/tmp/vitest-localstorage.json' npx vitest run src/common/images/primaryImage.component.test.tsx src/api/images.test.tsx --no-file-parallelism --maxWorkers=1` — passed (10 tests)
- [x] Run `npx eslint --max-warnings=0 src/api/images.tsx src/common/images/primaryImage.component.tsx src/common/images/primaryImage.component.test.tsx` — passed
- [ ] Run `npx tsc --noEmit` — blocked by existing unrelated TypeScript errors in catalogue/item/property form files

## Agile board tracking

connect to #1805
