### PR TITLE
yarn security

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,7 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
+
+npmMinimalAgeGate: '3d'
+
+enableScripts: false

--- a/package.json
+++ b/package.json
@@ -54,6 +54,17 @@
     "vite-plugin-css-injected-by-js": "^3.5.2",
     "zod": "^3.25.0"
   },
+  "dependenciesMeta": {
+    "cypress": {
+      "built": true
+    },
+    "esbuild": {
+      "built": true
+    },
+    "msw": {
+      "built": true
+    }
+  },
   "scripts": {
     "dev": "vite --open",
     "dev-docker": "vite --host",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6021,6 +6021,13 @@ __metadata:
     vite-plugin-css-injected-by-js: "npm:^3.5.2"
     vitest: "npm:4.1.8"
     zod: "npm:^3.25.0"
+  dependenciesMeta:
+    cypress:
+      built: true
+    esbuild:
+      built: true
+    msw:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

npmMinimalAgeGate: '3d'
-  Prevents installing very new packages (<3 days old) to reduce risk from malicious or compromised releases.

enableScripts: false
- Disables install-time scripts (e.g. postinstall) to stop dependencies from executing arbitrary code during install.

in yarn 4.14 this becomes default.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage