### PR TITLE
fix admin toggle bug

### DIFF
--- a/src/common/importTemplateDialog.component.tsx
+++ b/src/common/importTemplateDialog.component.tsx
@@ -161,17 +161,6 @@ const ImportTemplateDialog = (props: ImportTemplateDialogProps) => {
         uppyOnBeforeRequest(xhr);
       },
       getResponseData(xhr) {
-        if (!isAdminMode) {
-          const parsedHeaders = parseXHRHeaders(xhr.getAllResponseHeaders());
-          handleValidationHeaders({
-            headers: parsedHeaders,
-            parentName: parentName,
-            data: xhr.response,
-            uppy: newUppy,
-            isAdminMode: isAdminMode,
-          });
-        }
-
         return xhr.status === 204 ? '' : xhr.response;
       },
       async onAfterResponse(xhr) {
@@ -312,9 +301,23 @@ const ImportTemplateDialog = (props: ImportTemplateDialogProps) => {
     if (xhrPlugin) {
       xhrPlugin.setOptions({
         endpoint: `${imsIngestApiUrl}/spreadsheets/catalogue-items/${isAdminMode ? 'ingest' : 'validate'}`,
+        getResponseData: (xhr: XMLHttpRequest) => {
+          if (!isAdminMode) {
+            const parsedHeaders = parseXHRHeaders(xhr.getAllResponseHeaders());
+            handleValidationHeaders({
+              headers: parsedHeaders,
+              parentName: parentName,
+              data: xhr.response,
+              uppy: uppy,
+              isAdminMode: isAdminMode,
+            });
+          }
+
+          return xhr.status === 204 ? '' : xhr.response;
+        },
       });
     }
-  }, [isAdminMode, uppy, imsIngestApiUrl]);
+  }, [isAdminMode, uppy, imsIngestApiUrl, parentName]);
 
   React.useEffect(() => {
     const handleFileAdded = (
@@ -379,6 +382,7 @@ const ImportTemplateDialog = (props: ImportTemplateDialogProps) => {
         }}
         onRequestClose={handleClose}
         closeModalOnClickOutside={false}
+        showRemoveButtonAfterComplete={true}
         hideUploadButton={isPendingCatalogueItemsTemplateValidation}
         note={`Files cannot be larger than ${maxFileSizeMB}MB. Supported file types: ${spreadsheetAllowedFileExtensions.join(', ')}.`}
         animateOpenClose={false}


### PR DESCRIPTION
## Description

The admin toggle didn't update the uppy internal state as uppy is defined using a useState (https://uppy.io/docs/react/#example-updating-uppys-options-dynamically-based-on-props). If the options are dependent on a prop is should be set within the use effect

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

